### PR TITLE
Add tooling support for PostgreSQL client

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "postgresql"
-version = "1.1.0"
+version = "1.1.1"
 authors = ["Ballerina"]
 keywords = ["database", "client", "network", "SQL", "RDBMS", "PostgreSQL"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-postgresql"
@@ -9,10 +9,10 @@ license = ["Apache-2.0"]
 distribution = "slbeta3"
 
 [[platform.java11.dependency]]
-path = "../native/build/libs/postgresql-native-1.1.0.jar"
+path = "../native/build/libs/postgresql-native-1.1.1-SNAPSHOT.jar"
 
 [[platform.java11.dependency]]
-path = "./lib/sql-native-1.1.0.jar"
+path = "./lib/sql-native-1.1.1-20211126-000600-ddbfeed.jar"
 
 [[platform.java11.dependency]]
 path = "./lib/postgresql-42.2.20.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -1,0 +1,6 @@
+[plugin]
+id = "postgresql-compiler-plugin"
+class = "io.ballerina.stdlib.postgresql.compiler.PostgreSQLCompilerPlugin"
+
+[[dependency]]
+path = "../compiler-plugin/build/libs/postgresql-compiler-plugin-1.1.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -9,7 +9,7 @@ dependencies-toml-version = "2"
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -21,7 +21,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.0.1"
+version = "1.0.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
@@ -37,7 +37,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -94,7 +94,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.0.1"
+version = "2.0.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -115,7 +115,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "os"
-version = "1.0.1"
+version = "1.0.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
@@ -124,7 +124,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "regex"
-version = "1.0.1"
+version = "1.0.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
@@ -133,7 +133,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "sql"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -159,7 +159,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -170,7 +170,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "postgresql"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "file"},

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -252,6 +252,3 @@ build.finalizedBy stopTestDockerContainer
 test.dependsOn startTestDockerContainer
 test.dependsOn startTestPoolDockerContainer
 test.dependsOn startSslDockerContainer
-
-publishToMavenLocal.dependsOn build
-publish.dependsOn build

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -37,8 +37,11 @@ description = 'Ballerina - Postgresql Ballerina Generator'
 def packageName = 'postgresql'
 def packageOrg = 'ballerinax'
 def tomlVersion = stripBallerinaExtensionVersion("${project.version}")
+
 def ballerinaTomlFilePlaceHolder = new File("${project.rootDir}/build-config/resources/Ballerina.toml")
+def compilerPluginTomlFilePlaceHolder = new File("${project.rootDir}/build-config/resources/CompilerPlugin.toml")
 def ballerinaTomlFile = new File("$project.projectDir/Ballerina.toml")
+def compilerPluginTomlFile = new File("$project.projectDir/CompilerPlugin.toml")
 
 def stripBallerinaExtensionVersion(String extVersion) {
     if (extVersion.matches(project.ext.timestampedVersionRegex)) {
@@ -78,6 +81,9 @@ task updateTomlFiles {
         newConfig = newConfig.replace('@driver.version@', project.postgreSQLDriverVersion)
         newConfig = newConfig.replace('@stdlib.sql.version@', stdlibDependentSqlVersion)
         ballerinaTomlFile.text = newConfig
+
+        def newCompilerPluginToml = compilerPluginTomlFilePlaceHolder.text.replace("@project.version@", project.version)
+        compilerPluginTomlFile.text = newCompilerPluginToml
     }
 }
 
@@ -86,9 +92,9 @@ task commitTomlFiles {
         project.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-                commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" Ballerina.toml Dependencies.toml "
+                commandLine 'cmd', '/c', "git commit -m \"[Automated] Update the native jar versions\" Ballerina.toml Dependencies.toml CompilerPlugin.toml"
             } else {
-                commandLine 'sh', '-c', "git commit -m '[Automated] Update the native jar versions' Ballerina.toml Dependencies.toml"
+                commandLine 'sh', '-c', "git commit -m '[Automated] Update the native jar versions' Ballerina.toml Dependencies.toml CompilerPlugin.toml"
             }
         }
     }
@@ -248,6 +254,8 @@ startSslDockerContainer.dependsOn createTestDockerImage
 build.dependsOn "generatePomFileForMavenPublication"
 build.dependsOn ":${packageName}-native:build"
 test.dependsOn ":${packageName}-native:build"
+build.dependsOn ":${packageName}-compiler-plugin:build"
+test.dependsOn ":${packageName}-compiler-plugin:build"
 build.finalizedBy stopTestDockerContainer
 test.dependsOn startTestDockerContainer
 test.dependsOn startTestPoolDockerContainer

--- a/build-config/resources/CompilerPlugin.toml
+++ b/build-config/resources/CompilerPlugin.toml
@@ -1,0 +1,6 @@
+[plugin]
+id = "postgresql-compiler-plugin"
+class = "io.ballerina.stdlib.postgresql.compiler.PostgreSQLCompilerPlugin"
+
+[[dependency]]
+path = "../compiler-plugin/build/libs/postgresql-compiler-plugin-@project.version@.jar"

--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,7 @@ release {
 task build {
     dependsOn("${packageName}-native:build")
     dependsOn("${packageName}-ballerina:build")
+    dependsOn("${packageName}-compiler-plugin-tests:build")
     dependsOn("${packageName}-examples:build")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -116,5 +116,10 @@ release {
 }
 
 task build {
+    dependsOn("${packageName}-native:build")
     dependsOn("${packageName}-ballerina:build")
+    dependsOn("${packageName}-examples:build")
 }
+
+publishToMavenLocal.dependsOn build
+publish.dependsOn build

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ release {
 
 task build {
     dependsOn("${packageName}-native:build")
+    dependsOn("${packageName}-compiler-plugin:build")
     dependsOn("${packageName}-ballerina:build")
     dependsOn("${packageName}-compiler-plugin-tests:build")
     dependsOn("${packageName}-examples:build")

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- [Tooling support for Postgresql module](https://github.com/ballerina-platform/ballerina-standard-library/issues/2281)
 
 ### Changed
 

--- a/compiler-plugin-tests/build.gradle
+++ b/compiler-plugin-tests/build.gradle
@@ -22,13 +22,13 @@ plugins {
     id 'com.github.spotbugs'
 }
 
-description = 'Ballerina - Postgresql Compiler Plugin Tests'
+description = 'Ballerina - PostgreSQL Compiler Plugin Tests'
 
 dependencies {
     checkstyle project(':checkstyle')
     checkstyle "com.puppycrawl.tools:checkstyle:${puppycrawlCheckstyleVersion}"
 
-    // implementation project(':postgresql-compiler-plugin')
+    implementation project(':postgresql-compiler-plugin')
 
     testImplementation group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
     testImplementation group: 'org.ballerinalang', name: 'ballerina-tools-api', version: "${ballerinaLangVersion}"

--- a/compiler-plugin-tests/build.gradle
+++ b/compiler-plugin-tests/build.gradle
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+    id 'java'
+    id 'checkstyle'
+    id 'com.github.spotbugs'
+}
+
+description = 'Ballerina - Postgresql Compiler Plugin Tests'
+
+dependencies {
+    checkstyle project(':checkstyle')
+    checkstyle "com.puppycrawl.tools:checkstyle:${puppycrawlCheckstyleVersion}"
+
+    // implementation project(':postgresql-compiler-plugin')
+
+    testImplementation group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
+    testImplementation group: 'org.ballerinalang', name: 'ballerina-tools-api', version: "${ballerinaLangVersion}"
+    testImplementation group: 'org.ballerinalang', name: 'ballerina-parser', version: "${ballerinaLangVersion}"
+
+    implementation group: 'org.testng', name: 'testng', version: "${testngVersion}"
+}
+
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}
+
+sourceCompatibility = JavaVersion.VERSION_11
+
+test {
+    systemProperty "ballerina.offline.flag", "true"
+    useTestNG() {
+        suites 'src/test/resources/testng.xml'
+    }
+    testLogging.showStandardStreams = true
+    testLogging {
+        events "PASSED", "FAILED", "SKIPPED"
+        afterSuite { desc, result ->
+            if (!desc.parent) { // will match the outermost suite
+                def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} successes, ${result.failedTestCount} failures, ${result.skippedTestCount} skipped)"
+                def startItem = '|  ', endItem = '  |'
+                def repeatLength = startItem.length() + output.length() + endItem.length()
+                println('\n' + ('-' * repeatLength) + '\n' + startItem + output + endItem + '\n' + ('-' * repeatLength))
+            }
+        }
+    }
+}
+
+spotbugsTest {
+    ignoreFailures = true
+    effort = "max"
+    reportLevel = "low"
+    reportsDir = file("$project.buildDir/reports/spotbugs")
+    def excludeFile = file("${rootDir}/build-config/spotbugs-exclude.xml")
+    if (excludeFile.exists()) {
+        it.excludeFilter = excludeFile
+    }
+    reports {
+        text.enabled = true
+    }
+}
+
+spotbugsMain {
+    enabled false
+}
+
+task validateSpotbugs() {
+    doLast {
+        if (spotbugsMain.reports.size() > 0 &&
+                spotbugsMain.reports[0].destination.exists() &&
+                spotbugsMain.reports[0].destination.text.readLines().size() > 0) {
+            spotbugsMain.reports[0].destination?.eachLine {
+                println 'Failure: ' + it
+            }
+            throw new GradleException("Spotbugs rule violations were found.");
+        }
+    }
+}
+
+tasks.withType(Checkstyle) {
+    exclude '**/module-info.java'
+}
+
+checkstyle {
+    toolVersion "${project.puppycrawlCheckstyleVersion}"
+    configFile rootProject.file("build-config/checkstyle/build/checkstyle.xml")
+    configProperties = ["suppressionFile": file("${rootDir}/build-config/checkstyle/build/suppressions.xml")]
+}
+
+checkstyleMain {
+    enabled false
+}
+
+spotbugsTest.finalizedBy validateSpotbugs
+checkstyleTest.dependsOn ':checkstyle:downloadCheckstyleRuleFiles'
+
+compileJava {
+    doFirst {
+        options.compilerArgs = [
+                '--module-path', classpath.asPath,
+        ]
+        classpath = files()
+    }
+}
+
+test.dependsOn ":postgresql-ballerina:build"
+build.dependsOn ":postgresql-ballerina:build"

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/postgresql/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/postgresql/compiler/CompilerPluginTest.java
@@ -25,12 +25,16 @@ import io.ballerina.projects.ProjectEnvironmentBuilder;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.environment.Environment;
 import io.ballerina.projects.environment.EnvironmentBuilder;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticInfo;
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Tests the custom SQL compiler plugin.
@@ -54,13 +58,31 @@ public class CompilerPluginTest {
     }
 
     @Test
-    public void testBatchExecuteParam() {
+    public void testFunctionHints() {
         Package currentPackage = loadPackage("sample1");
         PackageCompilation compilation = currentPackage.getCompilation();
         DiagnosticResult diagnosticResult = compilation.diagnosticResult();
         long availableErrors = diagnosticResult.diagnostics().stream()
                 .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.ERROR)).count();
-        Assert.assertEquals(availableErrors, 0);
+        Assert.assertEquals(availableErrors, 3);
+
+        List<Diagnostic> diagnosticHints = diagnosticResult.diagnostics().stream()
+                .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.HINT))
+                .collect(Collectors.toList());
+        long availableHints = diagnosticHints.size();
+        Assert.assertEquals(availableHints, 3);
+
+        DiagnosticInfo hint1 = diagnosticHints.get(0).diagnosticInfo();
+        Assert.assertEquals(hint1.code(), PostgreSQLDiagnosticsCode.POSTGRESQL_901.getCode());
+        Assert.assertEquals(hint1.messageFormat(), PostgreSQLDiagnosticsCode.POSTGRESQL_901.getMessage());
+
+        DiagnosticInfo hint2 = diagnosticHints.get(1).diagnosticInfo();
+        Assert.assertEquals(hint2.code(), PostgreSQLDiagnosticsCode.POSTGRESQL_902.getCode());
+        Assert.assertEquals(hint2.messageFormat(), PostgreSQLDiagnosticsCode.POSTGRESQL_902.getMessage());
+
+        DiagnosticInfo hint3 = diagnosticHints.get(2).diagnosticInfo();
+        Assert.assertEquals(hint3.code(), PostgreSQLDiagnosticsCode.POSTGRESQL_901.getCode());
+        Assert.assertEquals(hint3.messageFormat(), PostgreSQLDiagnosticsCode.POSTGRESQL_901.getMessage());
     }
 
 }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/postgresql/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/postgresql/compiler/CompilerPluginTest.java
@@ -36,6 +36,8 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.SQL_101;
+
 /**
  * Tests the custom SQL compiler plugin.
  */
@@ -84,5 +86,24 @@ public class CompilerPluginTest {
         Assert.assertEquals(hint3.code(), PostgreSQLDiagnosticsCode.POSTGRESQL_901.getCode());
         Assert.assertEquals(hint3.messageFormat(), PostgreSQLDiagnosticsCode.POSTGRESQL_901.getMessage());
     }
+
+    @Test
+    public void testSQLConnectionPoolFieldsInNewExpression() {
+        Package currentPackage = loadPackage("sample2");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        List<Diagnostic> diagnosticErrorStream = diagnosticResult.diagnostics().stream()
+                .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.ERROR))
+                .collect(Collectors.toList());
+        long availableErrors = diagnosticErrorStream.size();
+
+        Assert.assertEquals(availableErrors, 2);
+
+        diagnosticErrorStream.forEach(diagnostic -> {
+            Assert.assertEquals(diagnostic.diagnosticInfo().code(), SQL_101.getCode());
+            Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(), SQL_101.getMessage());
+        });
+    }
+
 
 }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/postgresql/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/postgresql/compiler/CompilerPluginTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.postgresql.compiler;
+
+import io.ballerina.projects.DiagnosticResult;
+import io.ballerina.projects.Package;
+import io.ballerina.projects.PackageCompilation;
+import io.ballerina.projects.ProjectEnvironmentBuilder;
+import io.ballerina.projects.directory.BuildProject;
+import io.ballerina.projects.environment.Environment;
+import io.ballerina.projects.environment.EnvironmentBuilder;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Tests the custom SQL compiler plugin.
+ */
+public class CompilerPluginTest {
+
+    private static final Path RESOURCE_DIRECTORY = Paths.get("src", "test", "resources", "diagnostics")
+            .toAbsolutePath();
+    private static final Path DISTRIBUTION_PATH = Paths.get("../", "target", "ballerina-runtime")
+            .toAbsolutePath();
+
+    private static ProjectEnvironmentBuilder getEnvironmentBuilder() {
+        Environment environment = EnvironmentBuilder.getBuilder().setBallerinaHome(DISTRIBUTION_PATH).build();
+        return ProjectEnvironmentBuilder.getBuilder(environment);
+    }
+
+    private Package loadPackage(String path) {
+        Path projectDirPath = RESOURCE_DIRECTORY.resolve(path);
+        BuildProject project = BuildProject.load(getEnvironmentBuilder(), projectDirPath);
+        return project.currentPackage();
+    }
+
+    @Test
+    public void testBatchExecuteParam() {
+        Package currentPackage = loadPackage("sample1");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        long availableErrors = diagnosticResult.diagnostics().stream()
+                .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.ERROR)).count();
+        Assert.assertEquals(availableErrors, 0);
+    }
+
+}

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/postgresql/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/postgresql/compiler/CompilerPluginTest.java
@@ -36,6 +36,8 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.POSTGRESQL_101;
+import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.POSTGRESQL_102;
 import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.SQL_101;
 
 /**
@@ -97,13 +99,49 @@ public class CompilerPluginTest {
                 .collect(Collectors.toList());
         long availableErrors = diagnosticErrorStream.size();
 
-        Assert.assertEquals(availableErrors, 2);
+        Assert.assertEquals(availableErrors, 5);
 
-        diagnosticErrorStream.forEach(diagnostic -> {
-            Assert.assertEquals(diagnostic.diagnosticInfo().code(), SQL_101.getCode());
-            Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(), SQL_101.getMessage());
-        });
+        for (int i = 0; i < diagnosticErrorStream.size(); i++) {
+            Diagnostic diagnostic = diagnosticErrorStream.get(i);
+            switch (i) {
+                case 0:
+                case 3:
+                case 4:
+                    Assert.assertEquals(diagnostic.diagnosticInfo().code(), POSTGRESQL_101.getCode());
+                    Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(),
+                            POSTGRESQL_101.getMessage());
+                    break;
+                default:
+                    Assert.assertEquals(diagnostic.diagnosticInfo().code(), SQL_101.getCode());
+                    Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(),
+                            SQL_101.getMessage());
+            }
+        }
     }
 
+    @Test
+    public void testPostgreSQLOptionRecord() {
+        Package currentPackage = loadPackage("sample3");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        List<Diagnostic> diagnosticErrorStream = diagnosticResult.diagnostics().stream()
+                .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.ERROR))
+                .collect(Collectors.toList());
+        long availableErrors = diagnosticErrorStream.size();
 
+        Assert.assertEquals(availableErrors, 14);
+
+        for (int i = 0; i < diagnosticErrorStream.size(); i++) {
+            Diagnostic diagnostic = diagnosticErrorStream.get(i);
+            if (i <= 7) {
+                Assert.assertEquals(diagnostic.diagnosticInfo().code(), POSTGRESQL_101.getCode());
+                Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(),
+                        POSTGRESQL_101.getMessage());
+            } else {
+                Assert.assertEquals(diagnostic.diagnosticInfo().code(), POSTGRESQL_102.getCode());
+                Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(),
+                        POSTGRESQL_102.getMessage());
+            }
+        }
+    }
 }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/postgresql/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/postgresql/compiler/CompilerPluginTest.java
@@ -42,6 +42,7 @@ import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.
 import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.POSTGRESQL_202;
 import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.POSTGRESQL_203;
 import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.POSTGRESQL_204;
+import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.POSTGRESQL_903;
 import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.SQL_101;
 
 /**
@@ -176,5 +177,31 @@ public class CompilerPluginTest {
         diagnostic = errorDiagnosticsList.get(3).diagnosticInfo();
         Assert.assertEquals(diagnostic.code(), POSTGRESQL_204.getCode());
         Assert.assertEquals(diagnostic.messageFormat(), POSTGRESQL_204.getMessage());
+    }
+
+    @Test
+    public void testOutParameterHint() {
+        Package currentPackage = loadPackage("sample5");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        List<Diagnostic> errorDiagnosticsList = diagnosticResult.diagnostics().stream()
+                .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.ERROR))
+                .collect(Collectors.toList());
+        long availableErrors = errorDiagnosticsList.size();
+
+        Assert.assertEquals(availableErrors, 1);
+
+        List<Diagnostic> hintDiagnosticsList = diagnosticResult.diagnostics().stream()
+                .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.HINT))
+                .collect(Collectors.toList());
+        long availableHints = hintDiagnosticsList.size();
+
+        Assert.assertEquals(availableHints, 1);
+
+        hintDiagnosticsList.forEach(diagnostic -> {
+            Assert.assertEquals(diagnostic.diagnosticInfo().code(), POSTGRESQL_903.getCode());
+            Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(), POSTGRESQL_903.getMessage());
+        });
+
     }
 }

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/postgresql/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/postgresql/compiler/CompilerPluginTest.java
@@ -38,6 +38,10 @@ import java.util.stream.Collectors;
 
 import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.POSTGRESQL_101;
 import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.POSTGRESQL_102;
+import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.POSTGRESQL_201;
+import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.POSTGRESQL_202;
+import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.POSTGRESQL_203;
+import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.POSTGRESQL_204;
 import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.SQL_101;
 
 /**
@@ -143,5 +147,34 @@ public class CompilerPluginTest {
                         POSTGRESQL_102.getMessage());
             }
         }
+    }
+
+    @Test
+    public void testOutParameterValidations() {
+        Package currentPackage = loadPackage("sample4");
+        PackageCompilation compilation = currentPackage.getCompilation();
+        DiagnosticResult diagnosticResult = compilation.diagnosticResult();
+        List<Diagnostic> errorDiagnosticsList = diagnosticResult.diagnostics().stream()
+                .filter(r -> r.diagnosticInfo().severity().equals(DiagnosticSeverity.ERROR))
+                .collect(Collectors.toList());
+        long availableErrors = errorDiagnosticsList.size();
+
+        Assert.assertEquals(availableErrors, 4);
+
+        DiagnosticInfo diagnostic = errorDiagnosticsList.get(0).diagnosticInfo();
+        Assert.assertEquals(diagnostic.code(), POSTGRESQL_201.getCode());
+        Assert.assertEquals(diagnostic.messageFormat(), POSTGRESQL_201.getMessage());
+
+        diagnostic = errorDiagnosticsList.get(1).diagnosticInfo();
+        Assert.assertEquals(diagnostic.code(), POSTGRESQL_202.getCode());
+        Assert.assertEquals(diagnostic.messageFormat(), POSTGRESQL_202.getMessage());
+
+        diagnostic = errorDiagnosticsList.get(2).diagnosticInfo();
+        Assert.assertEquals(diagnostic.code(), POSTGRESQL_203.getCode());
+        Assert.assertEquals(diagnostic.messageFormat(), POSTGRESQL_203.getMessage());
+
+        diagnostic = errorDiagnosticsList.get(3).diagnosticInfo();
+        Assert.assertEquals(diagnostic.code(), POSTGRESQL_204.getCode());
+        Assert.assertEquals(diagnostic.messageFormat(), POSTGRESQL_204.getMessage());
     }
 }

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample1/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample1/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "postgresql_test"
+name = "sample1"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample1/main.bal
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample1/main.bal
@@ -1,0 +1,22 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/postgresql;
+
+public function main() returns error? {
+    postgresql:Client dbClient = check new();
+    check dbClient.close();
+}

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample1/main.bal
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample1/main.bal
@@ -18,5 +18,12 @@ import ballerinax/postgresql;
 
 public function main() returns error? {
     postgresql:Client dbClient = check new();
+    _ = check dbClient->query(``);
+    _ = check dbClient->queryRow(``);
+    check invokeQuery(dbClient);
     check dbClient.close();
+}
+
+function invokeQuery(postgresql:Client dbClient) returns error? {
+    _ = check dbClient->query(``);
 }

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample2/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample2/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "postgresql_test"
+name = "sample2"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample2/main.bal
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample2/main.bal
@@ -16,16 +16,16 @@
 
 import ballerinax/postgresql;
 
-postgresql:Client dbClient = check new postgresql:Client("url", (), (), (), 120, {}, { maxOpenConnections: -1 });
+postgresql:Client dbClient = check new postgresql:Client("url", (), (), (), 120, { loginTimeout: -2 }, { maxOpenConnections: -1 });
 
 public function main() returns error? {
 
     postgresql:Client dbClient1 = check new("url", connectionPool = { maxOpenConnections: -1 });
     check dbClient1.close();
 
-    postgresql:Client dbClient2 = check new("url", options = {});
+    postgresql:Client dbClient2 = check new("url", options = { loginTimeout: -2 });
     check dbClient2.close();
 
-    postgresql:Client dbClient3 = check new("url", (), (), (), 120, {});
+    postgresql:Client dbClient3 = check new("url", (), (), (), 120, { loginTimeout: -2 });
     check dbClient3.close();
 }

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample2/main.bal
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample2/main.bal
@@ -1,0 +1,31 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/postgresql;
+
+postgresql:Client dbClient = check new postgresql:Client("url", (), (), (), 120, {}, { maxOpenConnections: -1 });
+
+public function main() returns error? {
+
+    postgresql:Client dbClient1 = check new("url", connectionPool = { maxOpenConnections: -1 });
+    check dbClient1.close();
+
+    postgresql:Client dbClient2 = check new("url", options = {});
+    check dbClient2.close();
+
+    postgresql:Client dbClient3 = check new("url", (), (), (), 120, {});
+    check dbClient3.close();
+}

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample3/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample3/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "postgresql_test"
+name = "sample3"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample3/main.bal
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample3/main.bal
@@ -1,0 +1,53 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/postgresql;
+
+public function main() {
+
+    int id = 5;
+
+    int|postgresql:Options pool1 = 5;
+
+    int|postgresql:Options pool2 = {
+        loginTimeout: -2,
+        socketTimeout: -3
+    };
+
+    postgresql:Options|int pool3 = {
+        loginTimeout: -2,
+        socketTimeout: -3
+    };
+
+    postgresql:Options pool4 = {
+        ssl: {
+           mode: "PREFER"
+        },
+        connectTimeout: -1,
+        socketTimeout: -1,
+        loginTimeout: -1,
+        cancelSignalTimeout: -1,
+        rowFetchSize: 0,
+        cachedMetadataFieldsCount: -1,
+        cachedMetadataFieldSize: -1,
+        preparedStatementThreshold: -1,
+        preparedStatementCacheQueries: -1,
+        preparedStatementCacheSize: -1
+    };
+
+    postgresql:Options pool5 = {
+    };
+}

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample4/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample4/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "postgresql_test"
+name = "sample4"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample4/main.bal
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample4/main.bal
@@ -1,0 +1,32 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/postgresql;
+
+public function main() returns error? {
+    postgresql:InetOutParameter inetOut = new();
+    string inetVal = check inetOut.get(string);
+    int intVal = check inetOut.get(int);
+
+    postgresql:CircleOutParameter circleOut = new();
+    intVal = check circleOut.get(int);
+
+    postgresql:JsonOutParameter jsonOut = new();
+    intVal = check jsonOut.get(int);
+
+    postgresql:PGXmlOutParameter xmlOut = new();
+    intVal = check xmlOut.get(int);
+}

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample5/Ballerina.toml
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample5/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "postgresql_test"
+name = "sample5"
+version = "0.1.0"

--- a/compiler-plugin-tests/src/test/resources/diagnostics/sample5/main.bal
+++ b/compiler-plugin-tests/src/test/resources/diagnostics/sample5/main.bal
@@ -1,0 +1,24 @@
+// Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerinax/postgresql;
+
+public function main() returns error? {
+    postgresql:CircleOutParameter circleOut = new();
+    string value1 = check circleOut.get();
+    string value2 = check circleOut.get(string);
+    check circleOut.get();
+}

--- a/compiler-plugin-tests/src/test/resources/testng.xml
+++ b/compiler-plugin-tests/src/test/resources/testng.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<suite name="SQL compiler plugin test suite" parallel="false">
+
+    <test name="SQL Compiler Plugin Tests" parallel="false">
+        <classes>
+            <class name="io.ballerina.stdlib.postgresql.compiler.CompilerPluginTest"/>
+        </classes>
+    </test>
+</suite>

--- a/compiler-plugin/build.gradle
+++ b/compiler-plugin/build.gradle
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+    id 'java'
+    id 'checkstyle'
+    id 'com.github.spotbugs'
+}
+
+description = 'Ballerina - PostgreSQL Compiler Plugin'
+
+dependencies {
+    checkstyle project(':checkstyle')
+    checkstyle "com.puppycrawl.tools:checkstyle:${puppycrawlCheckstyleVersion}"
+
+    implementation group: 'org.ballerinalang', name: 'ballerina-lang', version: "${ballerinaLangVersion}"
+    implementation group: 'org.ballerinalang', name: 'ballerina-tools-api', version: "${ballerinaLangVersion}"
+    implementation group: 'org.ballerinalang', name: 'ballerina-parser', version: "${ballerinaLangVersion}"
+}
+
+def excludePattern = '**/module-info.java'
+tasks.withType(Checkstyle) {
+    exclude excludePattern
+}
+
+checkstyle {
+    toolVersion "${project.puppycrawlCheckstyleVersion}"
+    configFile rootProject.file("build-config/checkstyle/build/checkstyle.xml")
+    configProperties = ["suppressionFile" : file("${rootDir}/build-config/checkstyle/build/suppressions.xml")]
+}
+
+checkstyleMain.dependsOn(":checkstyle:downloadCheckstyleRuleFiles")
+
+spotbugsMain {
+    effort "max"
+    reportLevel "low"
+    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reports {
+        html.enabled true
+        text.enabled = true
+    }
+    def excludeFile = file("${rootDir}/spotbugs-exclude.xml")
+    if(excludeFile.exists()) {
+        excludeFilter = excludeFile
+    }
+}
+
+compileJava {
+    doFirst {
+        options.compilerArgs = [
+                '--module-path', classpath.asPath,
+        ]
+        classpath = files()
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/Constants.java
@@ -24,6 +24,7 @@ public class Constants {
     public static final String BALLERINAX = "ballerinax";
     public static final String POSTGRESQL = "postgresql";
     public static final String CONNECTION_POOL_PARAM_NAME = "connectionPool";
+    public static final String OPTIONS_PARAM_NAME = "options";
 
     /**
      * Constants related to Client object.
@@ -41,6 +42,24 @@ public class Constants {
         public static final String MAX_OPEN_CONNECTIONS = "maxOpenConnections";
         public static final String MAX_CONNECTION_LIFE_TIME = "maxConnectionLifeTime";
         public static final String MIN_IDLE_CONNECTIONS = "minIdleConnections";
+    }
+
+    /**
+     * Constants for fields in postgresql:Options.
+     */
+    public static class Options {
+        public static final String NAME = "Options";
+        public static final String CONNECT_TIMEOUT = "connectTimeout";
+        public static final String SOCKET_TIMEOUT = "socketTimeout";
+        public static final String LOGIN_TIMEOUT = "loginTimeout";
+        public static final String CANCEL_SIGNAL_TIMEOUT = "cancelSignalTimeout";
+
+        public static final String ROW_FETCH_SIZE = "rowFetchSize";
+        public static final String CACHED_METADATA_FIELD_COUNT = "cachedMetadataFieldsCount";
+        public static final String CACHED_METADATA_FIELD_SIZE = "cachedMetadataFieldSize";
+        public static final String PREPARED_STATEMENT_THRESHOLD = "preparedStatementThreshold";
+        public static final String PREPARED_STATEMENT_CACHE_QUERIES = "preparedStatementCacheQueries";
+        public static final String PREPARED_STATEMENT_CACHE_SIZE_MIB = "preparedStatementCacheSize";
     }
 
     public static final String UNNECESSARY_CHARS_REGEX = "\"|\\n";

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/Constants.java
@@ -23,6 +23,7 @@ package io.ballerina.stdlib.postgresql.compiler;
 public class Constants {
     public static final String BALLERINAX = "ballerinax";
     public static final String POSTGRESQL = "postgresql";
+    public static final String CONNECTION_POOL_PARAM_NAME = "connectionPool";
 
     /**
      * Constants related to Client object.
@@ -32,4 +33,16 @@ public class Constants {
         public static final String QUERY = "query";
         public static final String QUERY_ROW = "queryRow";
     }
+
+    /**
+     * Constants for fields in sql:ConnectionPool.
+     */
+    public static class ConnectionPool {
+        public static final String MAX_OPEN_CONNECTIONS = "maxOpenConnections";
+        public static final String MAX_CONNECTION_LIFE_TIME = "maxConnectionLifeTime";
+        public static final String MIN_IDLE_CONNECTIONS = "minIdleConnections";
+    }
+
+    public static final String UNNECESSARY_CHARS_REGEX = "\"|\\n";
+
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/Constants.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.stdlib.postgresql.compiler;
+
+/**
+ * Constants for PostgreSQL compiler plugin.
+ */
+public class Constants {
+    public static final String BALLERINAX = "ballerinax";
+    public static final String POSTGRESQL = "postgresql";
+
+    /**
+     * Constants related to Client object.
+     */
+    public static class Client {
+        public static final String CLIENT = "Client";
+        public static final String QUERY = "query";
+        public static final String QUERY_ROW = "queryRow";
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/Constants.java
@@ -25,12 +25,13 @@ public class Constants {
     public static final String POSTGRESQL = "postgresql";
     public static final String CONNECTION_POOL_PARAM_NAME = "connectionPool";
     public static final String OPTIONS_PARAM_NAME = "options";
+    public static final String OUT_PARAMETER_POSTFIX = "OutParameter";
 
     /**
      * Constants related to Client object.
      */
     public static class Client {
-        public static final String CLIENT = "Client";
+        public static final String NAME = "Client";
         public static final String QUERY = "query";
         public static final String QUERY_ROW = "queryRow";
     }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/Constants.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/Constants.java
@@ -62,6 +62,55 @@ public class Constants {
         public static final String PREPARED_STATEMENT_CACHE_SIZE_MIB = "preparedStatementCacheSize";
     }
 
+    /**
+     * Constants for fields in OutParameter objects.
+     */
+    public static class OutParameter {
+        public static final String METHOD_NAME = "get";
+
+        public static final String INET = "InetOutParameter";
+        public static final String CIDR = "CidrOutParameter";
+        public static final String MACADDR = "MacAddrOutParameter";
+        public static final String MACADDR8 = "MacAddr8OutParameter";
+        public static final String POINT = "PointOutParameter";
+        public static final String LINE = "LineOutParameter";
+        public static final String LSEG = "LsegOutParameter";
+        public static final String PATH = "PathOutParameter";
+        public static final String BOX = "BoxOutParameter";
+        public static final String POLYGON = "PolygonOutParameter";
+        public static final String CIRCLE = "CircleOutParameter";
+        public static final String UUID = "UuidOutParameter";
+        public static final String TSVECTOR = "TsVectorOutParameter";
+        public static final String TSQUERY = "TsQueryOutParameter";
+        public static final String JSON = "JsonOutParameter";
+        public static final String JSONB = "JsonbOutParameter";
+        public static final String JSONPATH = "JsonPathOutParameter";
+        public static final String INTERVAL = "IntervalOutParameter";
+        public static final String INT4RANGE = "IntegerRangeOutParameter";
+        public static final String INT8RANGE = "LongRangeOutParameter";
+        public static final String NUMRANGE = "NumericRangeOutParameter";
+        public static final String TSRANGE = "TimestampRangeOutParameter";
+        public static final String TSTZRANGE = "TimestampTzRangeOutParameter";
+        public static final String DATERANGE = "DateRangeOutParameter";
+        public static final String PGBIT = "PGBitOutParameter";
+        public static final String VARBITSTRING = "VarBitStringOutParameter";
+        public static final String BITSTRING = "BitStringOutParameter";
+        public static final String PGLSN = "PglsnOutParameter";
+        public static final String MONEY = "MoneyOutParameter";
+        public static final String REGCLASS = "RegClassOutParameter";
+        public static final String REGCONFIG = "RegConfigOutParameter";
+        public static final String REGDICTIONARY = "RegDictionaryOutParameter";
+        public static final String REGNAMESPACE = "RegNamespaceOutParameter";
+        public static final String REGOPER = "RegOperOutParameter";
+        public static final String REGOPERATOR = "RegOperatorOutParameter";
+        public static final String REGPROC = "RegProcOutParameter";
+        public static final String REGPROCEDURE = "RegProcedureOutParameter";
+        public static final String REGROLE = "RegRoleOutParameter";
+        public static final String REGTYPE = "RegTypeOutParameter";
+        public static final String BINARY = "ByteaOutParameter";
+        public static final String XML = "PGXmlOutParameter";
+    }
+
     public static final String UNNECESSARY_CHARS_REGEX = "\"|\\n";
 
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/PostgreSQLCodeAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/PostgreSQLCodeAnalyzer.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.projects.plugins.CodeAnalysisContext;
 import io.ballerina.projects.plugins.CodeAnalyzer;
 import io.ballerina.stdlib.postgresql.compiler.analyzer.InitializerParamAnalyzer;
+import io.ballerina.stdlib.postgresql.compiler.analyzer.MethodAnalyzer;
 import io.ballerina.stdlib.postgresql.compiler.analyzer.RecordAnalyzer;
 import io.ballerina.stdlib.postgresql.compiler.analyzer.RemoteMethodAnalyzer;
 
@@ -39,5 +40,6 @@ public class PostgreSQLCodeAnalyzer extends CodeAnalyzer {
                 List.of(SyntaxKind.IMPLICIT_NEW_EXPRESSION, SyntaxKind.EXPLICIT_NEW_EXPRESSION));
         ctx.addSyntaxNodeAnalysisTask(new RecordAnalyzer(),
                 List.of(SyntaxKind.LOCAL_VAR_DECL, SyntaxKind.MODULE_VAR_DECL));
+        ctx.addSyntaxNodeAnalysisTask(new MethodAnalyzer(), SyntaxKind.METHOD_CALL);
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/PostgreSQLCodeAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/PostgreSQLCodeAnalyzer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.postgresql.compiler;
+
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.projects.plugins.CodeAnalysisContext;
+import io.ballerina.projects.plugins.CodeAnalyzer;
+import io.ballerina.stdlib.postgresql.compiler.analyzer.RemoteMethodAnalyzer;
+
+/**
+ * PostgreSQL Code Analyzer.
+ */
+public class PostgreSQLCodeAnalyzer extends CodeAnalyzer {
+
+    @Override
+    public void init(CodeAnalysisContext codeAnalysisContext) {
+        codeAnalysisContext.addSyntaxNodeAnalysisTask(new RemoteMethodAnalyzer(), SyntaxKind.REMOTE_METHOD_CALL_ACTION);
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/PostgreSQLCodeAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/PostgreSQLCodeAnalyzer.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.projects.plugins.CodeAnalysisContext;
 import io.ballerina.projects.plugins.CodeAnalyzer;
 import io.ballerina.stdlib.postgresql.compiler.analyzer.InitializerParamAnalyzer;
+import io.ballerina.stdlib.postgresql.compiler.analyzer.RecordAnalyzer;
 import io.ballerina.stdlib.postgresql.compiler.analyzer.RemoteMethodAnalyzer;
 
 import java.util.List;
@@ -36,5 +37,7 @@ public class PostgreSQLCodeAnalyzer extends CodeAnalyzer {
         ctx.addSyntaxNodeAnalysisTask(new RemoteMethodAnalyzer(), SyntaxKind.REMOTE_METHOD_CALL_ACTION);
         ctx.addSyntaxNodeAnalysisTask(new InitializerParamAnalyzer(),
                 List.of(SyntaxKind.IMPLICIT_NEW_EXPRESSION, SyntaxKind.EXPLICIT_NEW_EXPRESSION));
+        ctx.addSyntaxNodeAnalysisTask(new RecordAnalyzer(),
+                List.of(SyntaxKind.LOCAL_VAR_DECL, SyntaxKind.MODULE_VAR_DECL));
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/PostgreSQLCodeAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/PostgreSQLCodeAnalyzer.java
@@ -21,7 +21,10 @@ package io.ballerina.stdlib.postgresql.compiler;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.projects.plugins.CodeAnalysisContext;
 import io.ballerina.projects.plugins.CodeAnalyzer;
+import io.ballerina.stdlib.postgresql.compiler.analyzer.InitializerParamAnalyzer;
 import io.ballerina.stdlib.postgresql.compiler.analyzer.RemoteMethodAnalyzer;
+
+import java.util.List;
 
 /**
  * PostgreSQL Code Analyzer.
@@ -29,7 +32,9 @@ import io.ballerina.stdlib.postgresql.compiler.analyzer.RemoteMethodAnalyzer;
 public class PostgreSQLCodeAnalyzer extends CodeAnalyzer {
 
     @Override
-    public void init(CodeAnalysisContext codeAnalysisContext) {
-        codeAnalysisContext.addSyntaxNodeAnalysisTask(new RemoteMethodAnalyzer(), SyntaxKind.REMOTE_METHOD_CALL_ACTION);
+    public void init(CodeAnalysisContext ctx) {
+        ctx.addSyntaxNodeAnalysisTask(new RemoteMethodAnalyzer(), SyntaxKind.REMOTE_METHOD_CALL_ACTION);
+        ctx.addSyntaxNodeAnalysisTask(new InitializerParamAnalyzer(),
+                List.of(SyntaxKind.IMPLICIT_NEW_EXPRESSION, SyntaxKind.EXPLICIT_NEW_EXPRESSION));
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/PostgreSQLCompilerPlugin.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/PostgreSQLCompilerPlugin.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.postgresql.compiler;
+
+import io.ballerina.projects.plugins.CompilerPlugin;
+import io.ballerina.projects.plugins.CompilerPluginContext;
+
+/**
+ * Compiler plugin for JDBC client.
+ */
+public class PostgreSQLCompilerPlugin extends CompilerPlugin {
+    @Override
+    public void init(CompilerPluginContext compilerPluginContext) {
+        compilerPluginContext.addCodeAnalyzer(new PostgreSQLCodeAnalyzer());
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/PostgreSQLDiagnosticsCode.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/PostgreSQLDiagnosticsCode.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.stdlib.postgresql.compiler;
+
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+
+import static io.ballerina.tools.diagnostics.DiagnosticSeverity.HINT;
+
+/**
+ * Enum class to hold JDBC module diagnostic codes.
+ */
+public enum PostgreSQLDiagnosticsCode {
+    POSTGRESQL_901("POSTGRESQL_901",
+            "parameter 'rowType' should be explicitly passed when the return data is ignored", HINT),
+    POSTGRESQL_902("POSTGRESQL_902",
+            "parameter 'returnType' should be explicitly passed when the return data is ignored", HINT);
+
+    private final String code;
+    private final String message;
+    private final DiagnosticSeverity severity;
+
+    PostgreSQLDiagnosticsCode(String code, String message, DiagnosticSeverity severity) {
+        this.code = code;
+        this.message = message;
+        this.severity = severity;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public DiagnosticSeverity getSeverity() {
+        return severity;
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/PostgreSQLDiagnosticsCode.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/PostgreSQLDiagnosticsCode.java
@@ -36,6 +36,12 @@ public enum PostgreSQLDiagnosticsCode {
     POSTGRESQL_101("POSTGRESQL_101", "invalid value: expected value is greater than or equal to zero", ERROR),
     POSTGRESQL_102("POSTGRESQL_102", "invalid value: expected value is greater than zero", ERROR),
 
+    // Out parameter return type validations diagnostics
+    POSTGRESQL_201("POSTGRESQL_201", "invalid value: expected value is string", ERROR),
+    POSTGRESQL_202("POSTGRESQL_202", "invalid value: expected value is either record or string", ERROR),
+    POSTGRESQL_203("POSTGRESQL_203", "invalid value: expected value is either json or string", ERROR),
+    POSTGRESQL_204("POSTGRESQL_204", "invalid value: expected value is either xml or string", ERROR),
+
     POSTGRESQL_901("POSTGRESQL_901",
             "parameter 'rowType' should be explicitly passed when the return data is ignored", HINT),
     POSTGRESQL_902("POSTGRESQL_902",

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/PostgreSQLDiagnosticsCode.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/PostgreSQLDiagnosticsCode.java
@@ -33,6 +33,9 @@ public enum PostgreSQLDiagnosticsCode {
     SQL_102("SQL_102", "invalid value: expected value is greater than zero", ERROR),
     SQL_103("SQL_103", "invalid value: expected value is greater than or equal to 30", ERROR),
 
+    POSTGRESQL_101("POSTGRESQL_101", "invalid value: expected value is greater than or equal to zero", ERROR),
+    POSTGRESQL_102("POSTGRESQL_102", "invalid value: expected value is greater than zero", ERROR),
+
     POSTGRESQL_901("POSTGRESQL_901",
             "parameter 'rowType' should be explicitly passed when the return data is ignored", HINT),
     POSTGRESQL_902("POSTGRESQL_902",

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/PostgreSQLDiagnosticsCode.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/PostgreSQLDiagnosticsCode.java
@@ -45,7 +45,10 @@ public enum PostgreSQLDiagnosticsCode {
     POSTGRESQL_901("POSTGRESQL_901",
             "parameter 'rowType' should be explicitly passed when the return data is ignored", HINT),
     POSTGRESQL_902("POSTGRESQL_902",
-            "parameter 'returnType' should be explicitly passed when the return data is ignored", HINT);
+            "parameter 'returnType' should be explicitly passed when the return data is ignored", HINT),
+    POSTGRESQL_903("POSTGRESQL_903",
+            "parameter 'typeDesc' should be explicitly passed when the return data is ignored", HINT);
+
 
     private final String code;
     private final String message;

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/PostgreSQLDiagnosticsCode.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/PostgreSQLDiagnosticsCode.java
@@ -19,12 +19,20 @@ package io.ballerina.stdlib.postgresql.compiler;
 
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 
+import static io.ballerina.tools.diagnostics.DiagnosticSeverity.ERROR;
 import static io.ballerina.tools.diagnostics.DiagnosticSeverity.HINT;
 
 /**
  * Enum class to hold JDBC module diagnostic codes.
  */
 public enum PostgreSQLDiagnosticsCode {
+
+    //SQL ConnectionPool Validations at init
+    // todo See if this can be taken from the dependency.
+    SQL_101("SQL_101", "invalid value: expected value is greater than one", ERROR),
+    SQL_102("SQL_102", "invalid value: expected value is greater than zero", ERROR),
+    SQL_103("SQL_103", "invalid value: expected value is greater than or equal to 30", ERROR),
+
     POSTGRESQL_901("POSTGRESQL_901",
             "parameter 'rowType' should be explicitly passed when the return data is ignored", HINT),
     POSTGRESQL_902("POSTGRESQL_902",

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/Utils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/Utils.java
@@ -22,10 +22,23 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.syntax.tree.BasicLiteralNode;
 import io.ballerina.compiler.syntax.tree.ExpressionNode;
+import io.ballerina.compiler.syntax.tree.MappingConstructorExpressionNode;
+import io.ballerina.compiler.syntax.tree.MappingFieldNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
+import io.ballerina.compiler.syntax.tree.SpecificFieldNode;
+import io.ballerina.compiler.syntax.tree.UnaryExpressionNode;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.tools.diagnostics.DiagnosticFactory;
+import io.ballerina.tools.diagnostics.DiagnosticInfo;
 
 import java.util.Optional;
+
+import static io.ballerina.stdlib.postgresql.compiler.Constants.UNNECESSARY_CHARS_REGEX;
+import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.POSTGRESQL_101;
+import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.POSTGRESQL_102;
 
 /**
  * Utils class.
@@ -60,5 +73,57 @@ public class Utils {
         }
         String objectName = typeReference.definition().getName().get();
         return objectName.equals(Constants.Client.CLIENT);
+    }
+
+    public static void validateOptions(SyntaxNodeAnalysisContext ctx, MappingConstructorExpressionNode options) {
+        SeparatedNodeList<MappingFieldNode> fields = options.fields();
+        for (MappingFieldNode field : fields) {
+            String name = ((SpecificFieldNode) field).fieldName().toString()
+                    .trim().replaceAll(UNNECESSARY_CHARS_REGEX, "");
+            ExpressionNode valueNode = ((SpecificFieldNode) field).valueExpr().get();
+            switch (name) {
+                case Constants.Options.CONNECT_TIMEOUT:
+                case Constants.Options.LOGIN_TIMEOUT:
+                case Constants.Options.SOCKET_TIMEOUT:
+                case Constants.Options.CANCEL_SIGNAL_TIMEOUT:
+                    float timeoutVal = Float.parseFloat(getTerminalNodeValue(valueNode));
+                    if (timeoutVal < 0) {
+                        DiagnosticInfo diagnosticInfo = new DiagnosticInfo(POSTGRESQL_101.getCode(),
+                                POSTGRESQL_101.getMessage(), POSTGRESQL_101.getSeverity());
+                        ctx.reportDiagnostic(
+                                DiagnosticFactory.createDiagnostic(diagnosticInfo, valueNode.location()));
+                    }
+                    break;
+                case Constants.Options.ROW_FETCH_SIZE:
+                case Constants.Options.CACHED_METADATA_FIELD_COUNT:
+                case Constants.Options.CACHED_METADATA_FIELD_SIZE:
+                case Constants.Options.PREPARED_STATEMENT_THRESHOLD:
+                case Constants.Options.PREPARED_STATEMENT_CACHE_QUERIES:
+                case Constants.Options.PREPARED_STATEMENT_CACHE_SIZE_MIB:
+                    int sizeVal = Integer.parseInt(getTerminalNodeValue(valueNode));
+                    if (sizeVal <= 0) {
+                        DiagnosticInfo diagnosticInfo = new DiagnosticInfo(POSTGRESQL_102.getCode(),
+                                POSTGRESQL_102.getMessage(), POSTGRESQL_102.getSeverity());
+                        ctx.reportDiagnostic(
+                                DiagnosticFactory.createDiagnostic(diagnosticInfo, valueNode.location()));
+                    }
+                    break;
+                default:
+                    // Can ignore all the other fields
+                    continue;
+            }
+        }
+    }
+
+    public static String getTerminalNodeValue(Node valueNode) {
+        String value = "";
+        if (valueNode instanceof BasicLiteralNode) {
+            value = ((BasicLiteralNode) valueNode).literalToken().text();
+        } else if (valueNode instanceof UnaryExpressionNode) {
+            UnaryExpressionNode unaryExpressionNode = (UnaryExpressionNode) valueNode;
+            value = unaryExpressionNode.unaryOperator() +
+                    ((BasicLiteralNode) unaryExpressionNode.expression()).literalToken().text();
+        }
+        return value.replaceAll(UNNECESSARY_CHARS_REGEX, "");
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/Utils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/Utils.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.stdlib.postgresql.compiler;
+
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.syntax.tree.ExpressionNode;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+
+import java.util.Optional;
+
+/**
+ * Utils class.
+ */
+public class Utils {
+    public static boolean isPostgreSQLClientObject(SyntaxNodeAnalysisContext ctx, ExpressionNode node) {
+        Optional<TypeSymbol> objectType = ctx.semanticModel().typeOf(node);
+        if (objectType.isEmpty()) {
+            return false;
+        }
+        if (objectType.get().typeKind() == TypeDescKind.UNION) {
+            return ((UnionTypeSymbol) objectType.get()).memberTypeDescriptors().stream()
+                    .filter(typeDescriptor -> typeDescriptor instanceof TypeReferenceTypeSymbol)
+                    .map(typeReferenceTypeSymbol -> (TypeReferenceTypeSymbol) typeReferenceTypeSymbol)
+                    .anyMatch(Utils::isPostgreSQLClientObject);
+        }
+        if (objectType.get() instanceof TypeReferenceTypeSymbol) {
+            return isPostgreSQLClientObject(((TypeReferenceTypeSymbol) objectType.get()));
+        }
+        return false;
+    }
+
+    public static boolean isPostgreSQLClientObject(TypeReferenceTypeSymbol typeReference) {
+        Optional<ModuleSymbol> optionalModuleSymbol = typeReference.getModule();
+        if (optionalModuleSymbol.isEmpty()) {
+            return false;
+        }
+        ModuleSymbol module = optionalModuleSymbol.get();
+        if (!(module.id().orgName().equals(Constants.BALLERINAX) &&
+                module.id().moduleName().equals(Constants.POSTGRESQL))) {
+            return false;
+        }
+        String objectName = typeReference.definition().getName().get();
+        return objectName.equals(Constants.Client.CLIENT);
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/analyzer/InitializerParamAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/analyzer/InitializerParamAnalyzer.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.stdlib.postgresql.compiler.analyzer;
+
+import io.ballerina.compiler.syntax.tree.BasicLiteralNode;
+import io.ballerina.compiler.syntax.tree.ExplicitNewExpressionNode;
+import io.ballerina.compiler.syntax.tree.ExpressionNode;
+import io.ballerina.compiler.syntax.tree.FunctionArgumentNode;
+import io.ballerina.compiler.syntax.tree.ImplicitNewExpressionNode;
+import io.ballerina.compiler.syntax.tree.MappingConstructorExpressionNode;
+import io.ballerina.compiler.syntax.tree.MappingFieldNode;
+import io.ballerina.compiler.syntax.tree.NamedArgumentNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.PositionalArgumentNode;
+import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
+import io.ballerina.compiler.syntax.tree.SpecificFieldNode;
+import io.ballerina.compiler.syntax.tree.UnaryExpressionNode;
+import io.ballerina.projects.plugins.AnalysisTask;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.stdlib.postgresql.compiler.Constants;
+import io.ballerina.stdlib.postgresql.compiler.Utils;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticFactory;
+import io.ballerina.tools.diagnostics.DiagnosticInfo;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.ballerina.stdlib.postgresql.compiler.Constants.CONNECTION_POOL_PARAM_NAME;
+import static io.ballerina.stdlib.postgresql.compiler.Constants.UNNECESSARY_CHARS_REGEX;
+import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.SQL_101;
+import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.SQL_102;
+import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.SQL_103;
+
+/**
+ * Validate fields of sql:Connection pool fields.
+ */
+public class InitializerParamAnalyzer implements AnalysisTask<SyntaxNodeAnalysisContext> {
+    @Override
+    public void perform(SyntaxNodeAnalysisContext ctx) {
+        List<Diagnostic> diagnostics = ctx.semanticModel().diagnostics();
+        for (Diagnostic diagnostic : diagnostics) {
+            if (diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR) {
+                return;
+            }
+        }
+
+        if (!(Utils.isPostgreSQLClientObject(ctx, ((ExpressionNode) ctx.node())))) {
+            return;
+        }
+
+        SeparatedNodeList<FunctionArgumentNode> arguments;
+        if (ctx.node() instanceof ImplicitNewExpressionNode) {
+            arguments = ((ImplicitNewExpressionNode) ctx.node()).parenthesizedArgList().get().arguments();
+        } else {
+            arguments = ((ExplicitNewExpressionNode) ctx.node()).parenthesizedArgList().arguments();
+        }
+
+        Optional<NamedArgumentNode> connectionPoolOptional = arguments.stream()
+                .filter(argNode -> argNode instanceof NamedArgumentNode)
+                .map(argNode -> (NamedArgumentNode) argNode)
+                .filter(arg -> arg.argumentName().name().text().equals(CONNECTION_POOL_PARAM_NAME))
+                .findFirst();
+        ExpressionNode connectionPool;
+        if (connectionPoolOptional.isPresent()) {
+            connectionPool = connectionPoolOptional.get().expression();
+        } else if (arguments.size() == 7) {
+            // All params are present
+            connectionPool = ((PositionalArgumentNode) arguments.get(6)).expression();
+        } else {
+            return;
+        }
+        SeparatedNodeList<MappingFieldNode> fields =
+                ((MappingConstructorExpressionNode) connectionPool).fields();
+        for (MappingFieldNode field : fields) {
+            String name = ((SpecificFieldNode) field).fieldName().toString()
+                    .trim().replaceAll(UNNECESSARY_CHARS_REGEX, "");
+            ExpressionNode valueNode = ((SpecificFieldNode) field).valueExpr().get();
+            switch (name) {
+                case Constants.ConnectionPool.MAX_OPEN_CONNECTIONS:
+                    int maxOpenConnections = Integer.parseInt(getTerminalNodeValue(valueNode));
+                    if (maxOpenConnections < 1) {
+                        DiagnosticInfo diagnosticInfo = new DiagnosticInfo(SQL_101.getCode(), SQL_101.getMessage(),
+                                SQL_101.getSeverity());
+
+                        ctx.reportDiagnostic(
+                                DiagnosticFactory.createDiagnostic(diagnosticInfo, valueNode.location()));
+
+                    }
+                    break;
+                case Constants.ConnectionPool.MIN_IDLE_CONNECTIONS:
+                    int minIdleConnection = Integer.parseInt(getTerminalNodeValue(valueNode));
+                    if (minIdleConnection < 0) {
+                        DiagnosticInfo diagnosticInfo = new DiagnosticInfo(SQL_102.getCode(), SQL_102.getMessage(),
+                                SQL_102.getSeverity());
+                        ctx.reportDiagnostic(
+                                DiagnosticFactory.createDiagnostic(diagnosticInfo, valueNode.location()));
+
+                    }
+                    break;
+                case Constants.ConnectionPool.MAX_CONNECTION_LIFE_TIME:
+                    float maxConnectionTime = Float.parseFloat(getTerminalNodeValue(valueNode));
+                    if (maxConnectionTime < 30) {
+                        DiagnosticInfo diagnosticInfo = new DiagnosticInfo(SQL_103.getCode(), SQL_103.getMessage(),
+                                SQL_103.getSeverity());
+                        ctx.reportDiagnostic(
+                                DiagnosticFactory.createDiagnostic(diagnosticInfo, valueNode.location()));
+
+                    }
+                    break;
+                default:
+                    // Can ignore all the other fields
+                    continue;
+            }
+        }
+    }
+
+    private String getTerminalNodeValue(Node valueNode) {
+        String value;
+        if (valueNode instanceof BasicLiteralNode) {
+            value = ((BasicLiteralNode) valueNode).literalToken().text();
+        } else {
+            UnaryExpressionNode unaryExpressionNode = (UnaryExpressionNode) valueNode;
+            value = unaryExpressionNode.unaryOperator() +
+                    ((BasicLiteralNode) unaryExpressionNode.expression()).literalToken().text();
+        }
+        return value.replaceAll(UNNECESSARY_CHARS_REGEX, "");
+    }
+
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/analyzer/InitializerParamAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/analyzer/InitializerParamAnalyzer.java
@@ -61,7 +61,7 @@ public class InitializerParamAnalyzer implements AnalysisTask<SyntaxNodeAnalysis
             }
         }
 
-        if (!(Utils.isPostgreSQLClientObject(ctx, ((ExpressionNode) ctx.node())))) {
+        if (!(Utils.isPostgreSQLObject(ctx, ((ExpressionNode) ctx.node()), Constants.Client.NAME))) {
             return;
         }
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/analyzer/InitializerParamAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/analyzer/InitializerParamAnalyzer.java
@@ -17,7 +17,6 @@
  */
 package io.ballerina.stdlib.postgresql.compiler.analyzer;
 
-import io.ballerina.compiler.syntax.tree.BasicLiteralNode;
 import io.ballerina.compiler.syntax.tree.ExplicitNewExpressionNode;
 import io.ballerina.compiler.syntax.tree.ExpressionNode;
 import io.ballerina.compiler.syntax.tree.FunctionArgumentNode;
@@ -25,11 +24,9 @@ import io.ballerina.compiler.syntax.tree.ImplicitNewExpressionNode;
 import io.ballerina.compiler.syntax.tree.MappingConstructorExpressionNode;
 import io.ballerina.compiler.syntax.tree.MappingFieldNode;
 import io.ballerina.compiler.syntax.tree.NamedArgumentNode;
-import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.PositionalArgumentNode;
 import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
 import io.ballerina.compiler.syntax.tree.SpecificFieldNode;
-import io.ballerina.compiler.syntax.tree.UnaryExpressionNode;
 import io.ballerina.projects.plugins.AnalysisTask;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
 import io.ballerina.stdlib.postgresql.compiler.Constants;
@@ -40,13 +37,16 @@ import io.ballerina.tools.diagnostics.DiagnosticInfo;
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 
 import java.util.List;
-import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static io.ballerina.stdlib.postgresql.compiler.Constants.CONNECTION_POOL_PARAM_NAME;
+import static io.ballerina.stdlib.postgresql.compiler.Constants.OPTIONS_PARAM_NAME;
 import static io.ballerina.stdlib.postgresql.compiler.Constants.UNNECESSARY_CHARS_REGEX;
 import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.SQL_101;
 import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.SQL_102;
 import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.SQL_103;
+import static io.ballerina.stdlib.postgresql.compiler.Utils.getTerminalNodeValue;
+import static io.ballerina.stdlib.postgresql.compiler.Utils.validateOptions;
 
 /**
  * Validate fields of sql:Connection pool fields.
@@ -72,22 +72,43 @@ public class InitializerParamAnalyzer implements AnalysisTask<SyntaxNodeAnalysis
             arguments = ((ExplicitNewExpressionNode) ctx.node()).parenthesizedArgList().arguments();
         }
 
-        Optional<NamedArgumentNode> connectionPoolOptional = arguments.stream()
+        List<NamedArgumentNode> namedArgumentNodes = arguments.stream()
                 .filter(argNode -> argNode instanceof NamedArgumentNode)
                 .map(argNode -> (NamedArgumentNode) argNode)
-                .filter(arg -> arg.argumentName().name().text().equals(CONNECTION_POOL_PARAM_NAME))
-                .findFirst();
-        ExpressionNode connectionPool;
-        if (connectionPoolOptional.isPresent()) {
-            connectionPool = connectionPoolOptional.get().expression();
+                .collect(Collectors.toList());
+
+        boolean namedNodeFound = namedArgumentNodes.size() > 0;
+
+        ExpressionNode options = null;
+        ExpressionNode connectionPool = null;
+        if (namedNodeFound) {
+            for (NamedArgumentNode node : namedArgumentNodes) {
+                if (node.argumentName().name().text().equals(OPTIONS_PARAM_NAME)) {
+                    options = node.expression();
+                }
+                if (node.argumentName().name().text().equals(CONNECTION_POOL_PARAM_NAME)) {
+                    connectionPool = node.expression();
+                }
+            }
         } else if (arguments.size() == 7) {
-            // All params are present
+            options = ((PositionalArgumentNode) arguments.get(5)).expression();
             connectionPool = ((PositionalArgumentNode) arguments.get(6)).expression();
+        } else if (arguments.size() == 6) {
+            options = ((PositionalArgumentNode) arguments.get(5)).expression();
         } else {
             return;
         }
-        SeparatedNodeList<MappingFieldNode> fields =
-                ((MappingConstructorExpressionNode) connectionPool).fields();
+
+        if (options instanceof MappingConstructorExpressionNode) {
+            validateOptions(ctx, (MappingConstructorExpressionNode) options);
+        }
+        if (connectionPool instanceof MappingConstructorExpressionNode) {
+            validateConnectionPool(ctx, (MappingConstructorExpressionNode) connectionPool);
+        }
+    }
+
+    private void validateConnectionPool(SyntaxNodeAnalysisContext ctx, MappingConstructorExpressionNode pool) {
+        SeparatedNodeList<MappingFieldNode> fields = pool.fields();
         for (MappingFieldNode field : fields) {
             String name = ((SpecificFieldNode) field).fieldName().toString()
                     .trim().replaceAll(UNNECESSARY_CHARS_REGEX, "");
@@ -129,18 +150,6 @@ public class InitializerParamAnalyzer implements AnalysisTask<SyntaxNodeAnalysis
                     continue;
             }
         }
-    }
-
-    private String getTerminalNodeValue(Node valueNode) {
-        String value;
-        if (valueNode instanceof BasicLiteralNode) {
-            value = ((BasicLiteralNode) valueNode).literalToken().text();
-        } else {
-            UnaryExpressionNode unaryExpressionNode = (UnaryExpressionNode) valueNode;
-            value = unaryExpressionNode.unaryOperator() +
-                    ((BasicLiteralNode) unaryExpressionNode.expression()).literalToken().text();
-        }
-        return value.replaceAll(UNNECESSARY_CHARS_REGEX, "");
     }
 
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/analyzer/MethodAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/analyzer/MethodAnalyzer.java
@@ -39,22 +39,31 @@ import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 import java.util.List;
 import java.util.Optional;
 
+import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.POSTGRESQL_903;
+import static org.ballerinalang.util.diagnostic.DiagnosticErrorCode.CANNOT_INFER_TYPE_FOR_PARAM;
+import static org.ballerinalang.util.diagnostic.DiagnosticErrorCode.INCOMPATIBLE_TYPE_FOR_INFERRED_TYPEDESC_VALUE;
+
 /**
  * Code Analyser for OutParameter get method type validations.
  */
 public class MethodAnalyzer implements AnalysisTask<SyntaxNodeAnalysisContext> {
     @Override
     public void perform(SyntaxNodeAnalysisContext ctx) {
+        MethodCallExpressionNode node = (MethodCallExpressionNode) ctx.node();
         List<Diagnostic> diagnostics = ctx.semanticModel().diagnostics();
-        for (Diagnostic diagnostic : diagnostics) {
-            if (diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR) {
-                return;
-            }
+        if (!diagnostics.isEmpty()) {
+            diagnostics.stream()
+                    .filter(diagnostic -> diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR)
+                    .filter(diagnostic ->
+                            diagnostic.diagnosticInfo().code().equals(CANNOT_INFER_TYPE_FOR_PARAM.diagnosticId()) ||
+                                    diagnostic.diagnosticInfo().code().equals(
+                                            INCOMPATIBLE_TYPE_FOR_INFERRED_TYPEDESC_VALUE.diagnosticId()))
+                    .filter(diagnostic -> diagnostic.location().lineRange().equals(node.location().lineRange()))
+                    .forEach(diagnostic -> addHint(ctx, node));
         }
 
-        MethodCallExpressionNode methodCallExpNode = (MethodCallExpressionNode) ctx.node();
         // Get the object type to validate arguments
-        ExpressionNode methodExpression = methodCallExpNode.expression();
+        ExpressionNode methodExpression = node.expression();
         Optional<TypeSymbol> methodExpReferenceType = ctx.semanticModel().typeOf(methodExpression);
         if (methodExpReferenceType.isEmpty()) {
             return;
@@ -75,7 +84,7 @@ public class MethodAnalyzer implements AnalysisTask<SyntaxNodeAnalysisContext> {
         String objectName = ((TypeReferenceTypeSymbol) methodExpReferenceType.get()).definition().getName().get();
 
         // Filter by method name, only OutParameter objects have get method
-        Optional<Symbol> methodSymbol = ctx.semanticModel().symbol(methodCallExpNode.methodName());
+        Optional<Symbol> methodSymbol = ctx.semanticModel().symbol(node.methodName());
         if (methodSymbol.isEmpty()) {
             return;
         }
@@ -88,17 +97,41 @@ public class MethodAnalyzer implements AnalysisTask<SyntaxNodeAnalysisContext> {
         }
 
         // Filter by parameters length
-        SeparatedNodeList<FunctionArgumentNode> arguments = methodCallExpNode.arguments();
+        SeparatedNodeList<FunctionArgumentNode> arguments = node.arguments();
         if (arguments.size() != 1) {
             return;
         }
-        TypeSymbol argumentTypeSymbol =
-                ((TypeSymbol) ctx.semanticModel().symbol(methodCallExpNode.arguments().get(0)).get());
+        TypeSymbol argumentTypeSymbol = ((TypeSymbol) ctx.semanticModel().symbol(node.arguments().get(0)).get());
         TypeDescKind argTypeKind = argumentTypeSymbol.typeKind();
         DiagnosticInfo diagnosticsForInvalidTypes = Utils.addDiagnosticsForInvalidTypes(objectName, argTypeKind);
         if (diagnosticsForInvalidTypes != null) {
             ctx.reportDiagnostic(DiagnosticFactory.createDiagnostic(diagnosticsForInvalidTypes,
-                    methodCallExpNode.arguments().get(0).location()));
+                    node.arguments().get(0).location()));
         }
+    }
+
+
+    private void addHint(SyntaxNodeAnalysisContext ctx, MethodCallExpressionNode node) {
+        if (!(Utils.isPostgreSQLObject(ctx, node.expression(), Constants.OUT_PARAMETER_POSTFIX))) {
+            return;
+        }
+        if (isGetMethod(ctx, node)) {
+            return;
+        }
+        ctx.reportDiagnostic(DiagnosticFactory.createDiagnostic(
+                new DiagnosticInfo(POSTGRESQL_903.getCode(), POSTGRESQL_903.getMessage(), POSTGRESQL_903.getSeverity()),
+                node.location()));
+    }
+
+    private boolean isGetMethod(SyntaxNodeAnalysisContext ctx, MethodCallExpressionNode node) {
+        Optional<Symbol> methodSymbol = ctx.semanticModel().symbol(node.methodName());
+        if (methodSymbol.isEmpty()) {
+            return true;
+        }
+        Optional<String> methodName = methodSymbol.get().getName();
+        if (methodName.isEmpty()) {
+            return true;
+        }
+        return !methodName.get().equals(Constants.OutParameter.METHOD_NAME);
     }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/analyzer/MethodAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/analyzer/MethodAnalyzer.java
@@ -101,7 +101,11 @@ public class MethodAnalyzer implements AnalysisTask<SyntaxNodeAnalysisContext> {
         if (arguments.size() != 1) {
             return;
         }
-        TypeSymbol argumentTypeSymbol = ((TypeSymbol) ctx.semanticModel().symbol(node.arguments().get(0)).get());
+        Optional<Symbol> typeDescriptionArgument = ctx.semanticModel().symbol(node.arguments().get(0));
+        if (typeDescriptionArgument.isEmpty()) {
+            return;
+        }
+        TypeSymbol argumentTypeSymbol = ((TypeSymbol) typeDescriptionArgument.get());
         TypeDescKind argTypeKind = argumentTypeSymbol.typeKind();
         DiagnosticInfo diagnosticsForInvalidTypes = Utils.addDiagnosticsForInvalidTypes(objectName, argTypeKind);
         if (diagnosticsForInvalidTypes != null) {

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/analyzer/MethodAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/analyzer/MethodAnalyzer.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.stdlib.postgresql.compiler.analyzer;
+
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.ExpressionNode;
+import io.ballerina.compiler.syntax.tree.FunctionArgumentNode;
+import io.ballerina.compiler.syntax.tree.MethodCallExpressionNode;
+import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
+import io.ballerina.projects.plugins.AnalysisTask;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.stdlib.postgresql.compiler.Constants;
+import io.ballerina.stdlib.postgresql.compiler.Utils;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticFactory;
+import io.ballerina.tools.diagnostics.DiagnosticInfo;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Code Analyser for OutParameter get method type validations.
+ */
+public class MethodAnalyzer implements AnalysisTask<SyntaxNodeAnalysisContext> {
+    @Override
+    public void perform(SyntaxNodeAnalysisContext ctx) {
+        List<Diagnostic> diagnostics = ctx.semanticModel().diagnostics();
+        for (Diagnostic diagnostic : diagnostics) {
+            if (diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR) {
+                return;
+            }
+        }
+
+        MethodCallExpressionNode methodCallExpNode = (MethodCallExpressionNode) ctx.node();
+        // Get the object type to validate arguments
+        ExpressionNode methodExpression = methodCallExpNode.expression();
+        Optional<TypeSymbol> methodExpReferenceType = ctx.semanticModel().typeOf(methodExpression);
+        if (methodExpReferenceType.isEmpty()) {
+            return;
+        }
+        if (methodExpReferenceType.get().typeKind() != TypeDescKind.TYPE_REFERENCE) {
+            return;
+        }
+        TypeReferenceTypeSymbol methodExpTypeSymbol = (TypeReferenceTypeSymbol) methodExpReferenceType.get();
+        Optional<ModuleSymbol> optionalModuleSymbol = methodExpTypeSymbol.getModule();
+        if (optionalModuleSymbol.isEmpty()) {
+            return;
+        }
+        ModuleSymbol module = optionalModuleSymbol.get();
+        if (!(module.id().orgName().equals(Constants.BALLERINAX)
+                && module.id().moduleName().equals(Constants.POSTGRESQL))) {
+            return;
+        }
+        String objectName = ((TypeReferenceTypeSymbol) methodExpReferenceType.get()).definition().getName().get();
+
+        // Filter by method name, only OutParameter objects have get method
+        Optional<Symbol> methodSymbol = ctx.semanticModel().symbol(methodCallExpNode.methodName());
+        if (methodSymbol.isEmpty()) {
+            return;
+        }
+        Optional<String> methodName = methodSymbol.get().getName();
+        if (methodName.isEmpty()) {
+            return;
+        }
+        if (!methodName.get().equals(Constants.OutParameter.METHOD_NAME)) {
+            return;
+        }
+
+        // Filter by parameters length
+        SeparatedNodeList<FunctionArgumentNode> arguments = methodCallExpNode.arguments();
+        if (arguments.size() != 1) {
+            return;
+        }
+        TypeSymbol argumentTypeSymbol =
+                ((TypeSymbol) ctx.semanticModel().symbol(methodCallExpNode.arguments().get(0)).get());
+        TypeDescKind argTypeKind = argumentTypeSymbol.typeKind();
+        DiagnosticInfo diagnosticsForInvalidTypes = Utils.addDiagnosticsForInvalidTypes(objectName, argTypeKind);
+        if (diagnosticsForInvalidTypes != null) {
+            ctx.reportDiagnostic(DiagnosticFactory.createDiagnostic(diagnosticsForInvalidTypes,
+                    methodCallExpNode.arguments().get(0).location()));
+        }
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/analyzer/RecordAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/analyzer/RecordAnalyzer.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.stdlib.postgresql.compiler.analyzer;
+
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.api.symbols.VariableSymbol;
+import io.ballerina.compiler.syntax.tree.ExpressionNode;
+import io.ballerina.compiler.syntax.tree.MappingConstructorExpressionNode;
+import io.ballerina.compiler.syntax.tree.ModuleVariableDeclarationNode;
+import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
+import io.ballerina.projects.plugins.AnalysisTask;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.stdlib.postgresql.compiler.Constants;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.ballerina.stdlib.postgresql.compiler.Constants.BALLERINAX;
+import static io.ballerina.stdlib.postgresql.compiler.Constants.POSTGRESQL;
+import static io.ballerina.stdlib.postgresql.compiler.Utils.validateOptions;
+
+/**
+ * Analyser for validation postgresql:Options.
+ */
+public class RecordAnalyzer implements AnalysisTask<SyntaxNodeAnalysisContext> {
+    @Override
+    public void perform(SyntaxNodeAnalysisContext ctx) {
+        List<Diagnostic> diagnostics = ctx.semanticModel().diagnostics();
+        for (Diagnostic diagnostic : diagnostics) {
+            if (diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR) {
+                return;
+            }
+        }
+        Optional<Symbol> varSymOptional = ctx.semanticModel().symbol(ctx.node());
+        if (varSymOptional.isPresent()) {
+            TypeSymbol typeSymbol = ((VariableSymbol) varSymOptional.get()).typeDescriptor();
+
+            if (isPostgreSQLOptionsRecord(typeSymbol, Constants.Options.NAME)) {
+                Optional<MappingConstructorExpressionNode> recordNode = getRecordNode(ctx);
+                if (recordNode.isEmpty()) {
+                    return;
+                }
+                validateOptions(ctx, recordNode.get());
+            }
+        }
+    }
+
+    private Optional<MappingConstructorExpressionNode> getRecordNode(SyntaxNodeAnalysisContext ctx) {
+        // Initiated with a record
+        Optional<ExpressionNode> optionalInitializer;
+        if ((ctx.node() instanceof VariableDeclarationNode)) {
+            // Function level variables
+            optionalInitializer = ((VariableDeclarationNode) ctx.node()).initializer();
+        } else {
+            // Module level variables
+            optionalInitializer = ((ModuleVariableDeclarationNode) ctx.node()).initializer();
+        }
+        if (optionalInitializer.isEmpty()) {
+            return Optional.empty();
+        }
+        ExpressionNode initializer = optionalInitializer.get();
+        if (!(initializer instanceof MappingConstructorExpressionNode)) {
+            return Optional.empty();
+        }
+        return Optional.of((MappingConstructorExpressionNode) initializer);
+    }
+
+    private boolean isPostgreSQLOptionsRecord(TypeSymbol type, String recordName) {
+        if (type.typeKind() == TypeDescKind.UNION) {
+            return ((UnionTypeSymbol) type).memberTypeDescriptors().stream()
+                    .filter(typeDescriptor -> typeDescriptor instanceof TypeReferenceTypeSymbol)
+                    .map(typeReferenceTypeSymbol -> (TypeReferenceTypeSymbol) typeReferenceTypeSymbol)
+                    .anyMatch(typeReferenceTypeSymbol ->
+                                                isPostgreSQLOptionsRecord(typeReferenceTypeSymbol, recordName));
+        }
+        if (type.typeKind() == TypeDescKind.TYPE_REFERENCE) {
+            return isPostgreSQLOptionsRecord((TypeReferenceTypeSymbol) type, recordName);
+        }
+        return false;
+    }
+
+    private boolean isPostgreSQLOptionsRecord(TypeReferenceTypeSymbol typeSymbol, String recordName) {
+        if (typeSymbol.typeDescriptor().typeKind() == TypeDescKind.RECORD) {
+            ModuleSymbol moduleSymbol = typeSymbol.getModule().get();
+            return POSTGRESQL.equals(moduleSymbol.getName().get()) && BALLERINAX.equals(moduleSymbol.id().orgName())
+                    && typeSymbol.definition().getName().get().equals(recordName);
+        }
+        return false;
+    }
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/analyzer/RemoteMethodAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/analyzer/RemoteMethodAnalyzer.java
@@ -17,15 +17,12 @@
  */
 package io.ballerina.stdlib.postgresql.compiler.analyzer;
 
-import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
-import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
-import io.ballerina.compiler.api.symbols.TypeSymbol;
-import io.ballerina.compiler.syntax.tree.ExpressionNode;
 import io.ballerina.compiler.syntax.tree.RemoteMethodCallActionNode;
 import io.ballerina.projects.plugins.AnalysisTask;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
 import io.ballerina.stdlib.postgresql.compiler.Constants;
+import io.ballerina.stdlib.postgresql.compiler.Utils;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.diagnostics.DiagnosticFactory;
 import io.ballerina.tools.diagnostics.DiagnosticInfo;
@@ -59,23 +56,7 @@ public class RemoteMethodAnalyzer implements AnalysisTask<SyntaxNodeAnalysisCont
     }
 
     private void addHint(SyntaxNodeAnalysisContext ctx, RemoteMethodCallActionNode node) {
-        ExpressionNode methodExpression = node.expression();
-        Optional<TypeSymbol> methodExpReferenceType = ctx.semanticModel().typeOf(methodExpression);
-        if (methodExpReferenceType.isEmpty()) {
-            return;
-        }
-        TypeReferenceTypeSymbol methodExpTypeSymbol = (TypeReferenceTypeSymbol) methodExpReferenceType.get();
-        Optional<ModuleSymbol> optionalModuleSymbol = methodExpTypeSymbol.getModule();
-        if (optionalModuleSymbol.isEmpty()) {
-            return;
-        }
-        ModuleSymbol module = optionalModuleSymbol.get();
-        if (!(module.id().orgName().equals(Constants.BALLERINAX) &&
-                module.id().moduleName().equals(Constants.POSTGRESQL))) {
-            return;
-        }
-        String objectName = ((TypeReferenceTypeSymbol) methodExpReferenceType.get()).definition().getName().get();
-        if (!objectName.equals(Constants.Client.CLIENT)) {
+        if (!(Utils.isPostgreSQLClientObject(ctx, node.expression()))) {
             return;
         }
 

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/analyzer/RemoteMethodAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/analyzer/RemoteMethodAnalyzer.java
@@ -17,12 +17,27 @@
  */
 package io.ballerina.stdlib.postgresql.compiler.analyzer;
 
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.ExpressionNode;
+import io.ballerina.compiler.syntax.tree.RemoteMethodCallActionNode;
 import io.ballerina.projects.plugins.AnalysisTask;
 import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.stdlib.postgresql.compiler.Constants;
 import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticFactory;
+import io.ballerina.tools.diagnostics.DiagnosticInfo;
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+import org.ballerinalang.util.diagnostic.DiagnosticErrorCode;
 
 import java.util.List;
+import java.util.Optional;
+
+import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.POSTGRESQL_901;
+import static io.ballerina.stdlib.postgresql.compiler.PostgreSQLDiagnosticsCode.POSTGRESQL_902;
+import static org.ballerinalang.util.diagnostic.DiagnosticErrorCode.CANNOT_INFER_TYPE_FOR_PARAM;
 
 /**
  * PostgreSQL Client remote call analyzer.
@@ -31,12 +46,61 @@ public class RemoteMethodAnalyzer implements AnalysisTask<SyntaxNodeAnalysisCont
 
     @Override
     public void perform(SyntaxNodeAnalysisContext ctx) {
+        RemoteMethodCallActionNode node = (RemoteMethodCallActionNode) ctx.node();
         List<Diagnostic> diagnostics = ctx.semanticModel().diagnostics();
-        for (Diagnostic diagnostic : diagnostics) {
-            if (diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR) {
-                return;
-            }
-        }
+        diagnostics.stream()
+                .filter(diagnostic -> diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR)
+                .filter(diagnostic ->
+                        diagnostic.diagnosticInfo().code().equals(CANNOT_INFER_TYPE_FOR_PARAM.diagnosticId()) ||
+                                diagnostic.diagnosticInfo().code().equals(
+                                   DiagnosticErrorCode.INCOMPATIBLE_TYPE_FOR_INFERRED_TYPEDESC_VALUE.diagnosticId()))
+                .filter(diagnostic -> diagnostic.location().lineRange().equals(node.location().lineRange()))
+                .forEach(diagnostic -> addHint(ctx, node));
     }
 
+    private void addHint(SyntaxNodeAnalysisContext ctx, RemoteMethodCallActionNode node) {
+        ExpressionNode methodExpression = node.expression();
+        Optional<TypeSymbol> methodExpReferenceType = ctx.semanticModel().typeOf(methodExpression);
+        if (methodExpReferenceType.isEmpty()) {
+            return;
+        }
+        TypeReferenceTypeSymbol methodExpTypeSymbol = (TypeReferenceTypeSymbol) methodExpReferenceType.get();
+        Optional<ModuleSymbol> optionalModuleSymbol = methodExpTypeSymbol.getModule();
+        if (optionalModuleSymbol.isEmpty()) {
+            return;
+        }
+        ModuleSymbol module = optionalModuleSymbol.get();
+        if (!(module.id().orgName().equals(Constants.BALLERINAX) &&
+                module.id().moduleName().equals(Constants.POSTGRESQL))) {
+            return;
+        }
+        String objectName = ((TypeReferenceTypeSymbol) methodExpReferenceType.get()).definition().getName().get();
+        if (!objectName.equals(Constants.Client.CLIENT)) {
+            return;
+        }
+
+        Optional<Symbol> methodSymbol = ctx.semanticModel().symbol(node.methodName());
+        if (methodSymbol.isEmpty()) {
+            return;
+        }
+        Optional<String> methodName = methodSymbol.get().getName();
+        if (methodName.isEmpty()) {
+            return;
+        }
+
+        switch (methodName.get()) {
+            case Constants.Client.QUERY:
+                ctx.reportDiagnostic(DiagnosticFactory.createDiagnostic(
+                        new DiagnosticInfo(POSTGRESQL_901.getCode(), POSTGRESQL_901.getMessage(),
+                                POSTGRESQL_901.getSeverity()), node.location()));
+                break;
+            case Constants.Client.QUERY_ROW:
+                ctx.reportDiagnostic(DiagnosticFactory.createDiagnostic(
+                        new DiagnosticInfo(POSTGRESQL_902.getCode(), POSTGRESQL_902.getMessage(),
+                                POSTGRESQL_902.getSeverity()), node.location()));
+                break;
+            default:
+                return;
+        }
+    }
 }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/analyzer/RemoteMethodAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/analyzer/RemoteMethodAnalyzer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.stdlib.postgresql.compiler.analyzer;
+
+import io.ballerina.projects.plugins.AnalysisTask;
+import io.ballerina.projects.plugins.SyntaxNodeAnalysisContext;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
+
+import java.util.List;
+
+/**
+ * PostgreSQL Client remote call analyzer.
+ */
+public class RemoteMethodAnalyzer implements AnalysisTask<SyntaxNodeAnalysisContext> {
+
+    @Override
+    public void perform(SyntaxNodeAnalysisContext ctx) {
+        List<Diagnostic> diagnostics = ctx.semanticModel().diagnostics();
+        for (Diagnostic diagnostic : diagnostics) {
+            if (diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR) {
+                return;
+            }
+        }
+    }
+
+}

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/analyzer/RemoteMethodAnalyzer.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/analyzer/RemoteMethodAnalyzer.java
@@ -56,7 +56,7 @@ public class RemoteMethodAnalyzer implements AnalysisTask<SyntaxNodeAnalysisCont
     }
 
     private void addHint(SyntaxNodeAnalysisContext ctx, RemoteMethodCallActionNode node) {
-        if (!(Utils.isPostgreSQLClientObject(ctx, node.expression()))) {
+        if (!(Utils.isPostgreSQLObject(ctx, node.expression(), Constants.Client.NAME))) {
             return;
         }
 

--- a/compiler-plugin/src/main/java/module-info.java
+++ b/compiler-plugin/src/main/java/module-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+module io.ballerina.stdlib.postgresql.compiler {
+    requires io.ballerina.lang;
+    requires io.ballerina.tools.api;
+    requires io.ballerina.parser;
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,7 @@ githubSpotbugsVersion=4.0.5
 githubJohnrengelmanShadowVersion=5.2.0
 underCouchDownloadVersion=4.0.4
 researchgateReleaseVersion=2.8.0
+testngVersion=7.4.0
 ballerinaGradlePluginVersion=0.14.1
 
 ballerinaLangVersion=2.0.0-beta.5-20211125-162900-862e8e5a

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,11 +16,13 @@ rootProject.name = 'ballerinax-postgresql'
 include ':checkstyle'
 include ':postgresql-native'
 include ':postgresql-ballerina'
+include ':postgresql-compiler-plugin-tests'
 include ':postgresql-examples'
 
 project(':checkstyle').projectDir = file("build-config${File.separator}checkstyle")
 project(':postgresql-native').projectDir = file('native')
 project(':postgresql-ballerina').projectDir = file('ballerina')
+project(':postgresql-compiler-plugin-tests').projectDir = file('compiler-plugin-tests')
 project(':postgresql-examples').projectDir = file('examples')
 
 gradleEnterprise {

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,12 +15,14 @@ rootProject.name = 'ballerinax-postgresql'
 
 include ':checkstyle'
 include ':postgresql-native'
+include ':postgresql-compiler-plugin'
 include ':postgresql-ballerina'
 include ':postgresql-compiler-plugin-tests'
 include ':postgresql-examples'
 
 project(':checkstyle').projectDir = file("build-config${File.separator}checkstyle")
 project(':postgresql-native').projectDir = file('native')
+project(':postgresql-compiler-plugin').projectDir = file('compiler-plugin')
 project(':postgresql-ballerina').projectDir = file('ballerina')
 project(':postgresql-compiler-plugin-tests').projectDir = file('compiler-plugin-tests')
 project(':postgresql-examples').projectDir = file('examples')


### PR DESCRIPTION
## Purpose
$subject

Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/2281

## Examples
- Validating nonzero int/float values for postgresql:Options in variable declaration and initialization,
<img width="749" alt="Screenshot 2021-11-27 at 20 25 33" src="https://user-images.githubusercontent.com/27669465/143719878-c9aa68fa-8c09-4870-8267-018135235c4a.png">

- Validate fields of sql:ConnectionPool param in connector initialization,
<img width="1059" alt="Screenshot 2021-11-27 at 20 24 35" src="https://user-images.githubusercontent.com/27669465/143719875-3e7925de-4766-4aa8-87ff-b4d896342ade.png">

- Validate supported types for get() method in OutParameters,
<img width="795" alt="Screenshot 2021-11-27 at 20 28 03" src="https://user-images.githubusercontent.com/27669465/143719881-1894e0ba-3ad9-4c5c-804f-fdf2ff09f473.png">

- Add hints when query() and queryRow() methods cannot infer the return type description.
- Add hints when get() method of OutParameters cannot infer the return type description.

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests