### PR TITLE
Extend daily-build workflow to check breaking changes

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set environment variable
         if: github.event.action == 'check_connector_for_breaking_changes'
         run: |
-          echo "CHECK_BRAEKING_CHANGES=true" >> $GITHUB_ENV
+          echo "BUILD_USING_DOCKER=true" >> $GITHUB_ENV
           echo "GRADLE_SKIP_TASKS=-x :postgresql-compiler-plugin-tests:test"  >> $GITHUB_ENV
 
       # Build the project with Gradle

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '30 2 * * *'
+  repository_dispatch:
+    types:
+      check_connector_for_breaking_changes
 
 jobs:
   build:
@@ -18,25 +21,38 @@ jobs:
           distribution: 'adopt'
           java-version: 11
 
+      - name: Set environment variable
+        if: github.event.action == 'check_connector_for_breaking_changes'
+        run: |
+          echo "CHECK_BRAEKING_CHANGES=true" >> $GITHUB_ENV
+          echo "GRADLE_SKIP_TASKS=-x :postgresql-compiler-plugin-tests:test"  >> $GITHUB_ENV
+
       # Build the project with Gradle
       - name: Build with Gradle
         env:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ./gradlew clean build
+          ./gradlew clean build $GRADLE_SKIP_TASKS
 
       # Send notification when build fails
       - name: Notify failure
         if: ${{ failure() }}
         run: |
+          eventType="notify-build-failure"
+
+          if [[ "${{ github.event.action }}" == "check_connector_for_breaking_changes" ]]; then
+            eventType="notify-ballerinax-connector-build-failure"
+          fi
+
           curl -X POST \
           'https://api.github.com/repos/ballerina-platform/ballerina-release/dispatches' \
           -H 'Accept: application/vnd.github.v3+json' \
           -H 'Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}' \
           --data "{
-            \"event_type\": \"notify-build-failure\",
+            \"event_type\": \"$eventType\",
             \"client_payload\": {
-              \"repoName\": \"module-ballerinax-postgresql\"
+              \"repoName\": \"module-ballerinax-postgresql\",
+              \"workflow\": \"Daily build\"
             }
           }"

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -246,13 +246,8 @@ task stopTestDockerContainer() {
     }
 }
 
-def checkForBreakingChanges = (System.getenv('CHECK_BRAEKING_CHANGES') == "true")
 
-if (checkForBreakingChanges) {
-    updateTomlFiles.dependsOn copyToLib
-} else {
-    updateTomlFiles.dependsOn copyStdlibs
-}
+updateTomlFiles.dependsOn copyStdlibs
 
 startTestDockerContainer.dependsOn createTestDockerImage
 startTestPoolDockerContainer.dependsOn createTestDockerImage

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -246,7 +246,14 @@ task stopTestDockerContainer() {
     }
 }
 
-updateTomlFiles.dependsOn copyStdlibs
+def checkForBreakingChanges = (System.getenv('CHECK_BRAEKING_CHANGES') == "true")
+
+if (checkForBreakingChanges) {
+    updateTomlFiles.dependsOn copyToLib
+} else {
+    updateTomlFiles.dependsOn copyStdlibs
+}
+
 startTestDockerContainer.dependsOn createTestDockerImage
 startTestPoolDockerContainer.dependsOn createTestDockerImage
 startSslDockerContainer.dependsOn createTestDockerImage


### PR DESCRIPTION
## Purpose
Extend daily-build workflow to check breaking changes on repository dispatch.
Related PR [@1981](https://github.com/ballerina-platform/ballerina-release/pull/1981), [@77](https://github.com/ballerina-platform/plugin-gradle/pull/77)
