### PR TITLE
Add .cache directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ gradle-app.setting
 .project
 .settings
 .vscode
+.cache
 
 # log files
 **/test_log.conf


### PR DESCRIPTION
## Purpose

$subject.

Publish release failed with the following error in `checkCommitNeeded` action.
```
Execution failed for task ':module-ballerinax-postgresql:checkCommitNeeded'.
> You have unversioned files:
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ?? .cache/
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Hence ignore .cache directory.

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
