### PR TITLE
Allow preparedStatementThreshold to be 0 to disable the cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ gradle-app.setting
 .project
 .settings
 .vscode
+.cache
 
 # log files
 **/test_log.conf

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -149,9 +149,11 @@ type ClientConfiguration record {|
 # + cachedMetadataFieldSize - The maximum size (in megabytes) of fields to be cached per connection.
 #                             A value of 0 disables the cache
 # + preparedStatementThreshold - The number of `PreparedStatement` executions required before switching
-#                                over to use server-side prepared statements
+#                                over to use server-side prepared statements. A value of 0 disables the cache.
 # + preparedStatementCacheQueries - The number of queries that are cached in each connection
+#                                   A value of 0 for preparedStatementThreshold disables the cache.
 # + preparedStatementCacheSize - The maximum size (in mebibytes) of the prepared queries
+#                                  A value of 0 for preparedStatementThreshold disables the cache.
 # + cancelSignalTimeout - Time (in seconds) by which the cancel command is sent out of band over its own connection
 #                         so that the cancel message itself can get stuck. The default value is 10 seconds
 # + keepAliveTcpProbe - Enable or disable the TCP keep-alive probe

--- a/ballerina/tests/connection-init-test.bal
+++ b/ballerina/tests/connection-init-test.bal
@@ -120,9 +120,9 @@ function testWithOptions2() returns error? {
         rowFetchSize: 0,
         cachedMetadataFieldsCount: 0,
         cachedMetadataFieldSize: 0,
-        preparedStatementThreshold: 0,
-        preparedStatementCacheQueries: 0,
-        preparedStatementCacheSize: 0,
+        preparedStatementThreshold: -1,
+        preparedStatementCacheQueries: -1,
+        preparedStatementCacheSize: -1,
         cancelSignalTimeout: 0,
         keepAliveTcpProbe: false
     };
@@ -240,7 +240,7 @@ function testWithConnectionParams3() returns error? {
         rowFetchSize: 20,
         cachedMetadataFieldsCount: 65536,
         cachedMetadataFieldSize: 5,
-        preparedStatementThreshold: 5,
+        preparedStatementThreshold: 0,
         preparedStatementCacheQueries: 256,
         preparedStatementCacheSize: 5,
         cancelSignalTimeout: 10,

--- a/changelog.md
+++ b/changelog.md
@@ -7,8 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-
-### Changed
+- [Allow prepareThreshold, preparedStatementCacheQueries and preparedStatementCacheSizeMiB to pass 0 values](https://github.com/ballerina-platform/ballerina-standard-library/issues/7345)
 
 ## [1.10.0] - 2023-06-30
 

--- a/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/postgresql/compiler/CompilerPluginTest.java
+++ b/compiler-plugin-tests/src/test/java/io/ballerina/stdlib/postgresql/compiler/CompilerPluginTest.java
@@ -109,14 +109,14 @@ public class CompilerPluginTest {
 
         for (int i = 0; i < diagnosticErrorStream.size(); i++) {
             Diagnostic diagnostic = diagnosticErrorStream.get(i);
-            if (i <= 7) {
-                Assert.assertEquals(diagnostic.diagnosticInfo().code(), POSTGRESQL_101.getCode());
-                Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(),
-                        POSTGRESQL_101.getMessage());
-            } else {
+            if (8 <= i && i <= 10) {
                 Assert.assertEquals(diagnostic.diagnosticInfo().code(), POSTGRESQL_102.getCode());
                 Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(),
                         POSTGRESQL_102.getMessage());
+            } else {
+                Assert.assertEquals(diagnostic.diagnosticInfo().code(), POSTGRESQL_101.getCode());
+                Assert.assertEquals(diagnostic.diagnosticInfo().messageFormat(),
+                        POSTGRESQL_101.getMessage());
             }
         }
     }

--- a/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/Utils.java
+++ b/compiler-plugin/src/main/java/io/ballerina/stdlib/postgresql/compiler/Utils.java
@@ -153,13 +153,21 @@ public class Utils {
             case Constants.Options.ROW_FETCH_SIZE:
             case Constants.Options.CACHED_METADATA_FIELD_COUNT:
             case Constants.Options.CACHED_METADATA_FIELD_SIZE:
-            case Constants.Options.PREPARED_STATEMENT_THRESHOLD:
-            case Constants.Options.PREPARED_STATEMENT_CACHE_QUERIES:
-            case Constants.Options.PREPARED_STATEMENT_CACHE_SIZE_MIB:
                 int sizeVal = Integer.parseInt(getTerminalNodeValue(valueNode, "1"));
                 if (sizeVal <= 0) {
                     DiagnosticInfo diagnosticInfo = new DiagnosticInfo(POSTGRESQL_102.getCode(),
                             POSTGRESQL_102.getMessage(), POSTGRESQL_102.getSeverity());
+                    ctx.reportDiagnostic(
+                            DiagnosticFactory.createDiagnostic(diagnosticInfo, valueNode.location()));
+                }
+                break;
+            case Constants.Options.PREPARED_STATEMENT_THRESHOLD:
+            case Constants.Options.PREPARED_STATEMENT_CACHE_QUERIES:
+            case Constants.Options.PREPARED_STATEMENT_CACHE_SIZE_MIB:
+                int thresholdVal = Integer.parseInt(getTerminalNodeValue(valueNode, "0"));
+                if (thresholdVal < 0) {
+                    DiagnosticInfo diagnosticInfo = new DiagnosticInfo(POSTGRESQL_101.getCode(),
+                            POSTGRESQL_101.getMessage(), POSTGRESQL_101.getSeverity());
                     ctx.reportDiagnostic(
                             DiagnosticFactory.createDiagnostic(diagnosticInfo, valueNode.location()));
                 }

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -78,9 +78,11 @@ public isolated function init(string host = "localhost", string? username = "pos
   # + cachedMetadataFieldSize - The maximum size (in megabytes) of fields to be cached per connection.
   #                             A value of 0 disables the cache
   # + preparedStatementThreshold - The number of `PreparedStatement` executions required before switching
-  #                                over to use server-side prepared statements
+  #                                over to use server-side prepared statements. A value of 0 disables the cache.
   # + preparedStatementCacheQueries - The number of queries that are cached in each connection
+  #                                   A value of 0 for preparedStatementThreshold disables the cache.
   # + preparedStatementCacheSize - The maximum size (in mebibytes) of the prepared queries
+  #                                  A value of 0 for preparedStatementThreshold disables the cache.
   # + cancelSignalTimeout - Time (in seconds) by which the cancel command is sent out of band over its own connection
   #                         so that the cancel message itself can get stuck. The default value is 10 seconds
   # + keepAliveTcpProbe - Enable or disable the TCP keep-alive probe

--- a/native/src/main/java/io/ballerina/stdlib/postgresql/utils/Utils.java
+++ b/native/src/main/java/io/ballerina/stdlib/postgresql/utils/Utils.java
@@ -66,14 +66,14 @@ public class Utils {
             if (postgresqlOptions.containsKey(Constants.Options.PREPARE_THRESHOLD)) {
                 long preparedStatementThreshold = getIntegerValue(postgresqlOptions.
                                     getIntValue(Constants.Options.PREPARE_THRESHOLD));
-                if (preparedStatementThreshold > 0) {
+                if (preparedStatementThreshold >= 0) {
                     options.put(Constants.DatabaseProps.PREPARE_THRESHOLD, preparedStatementThreshold);
                 }
             }
             if (postgresqlOptions.containsKey(Constants.Options.PREPARED_STATEMENT_CACHE_QUERIES)) {
                 long preparedStatementCacheQueries = getIntegerValue(postgresqlOptions
                                     .getIntValue(Constants.Options.PREPARED_STATEMENT_CACHE_QUERIES));
-                if (preparedStatementCacheQueries > 0) {
+                if (preparedStatementCacheQueries >= 0) {
                     options.put(Constants.DatabaseProps.PREPARED_STATEMENT_CACHE_QUERIES,
                                      preparedStatementCacheQueries);
                 }
@@ -81,7 +81,7 @@ public class Utils {
             if (postgresqlOptions.containsKey(Constants.Options.PREPARED_STATEMENT_CACHE_QUERIES)) {
                 long preparedStatementCacheSize = getIntegerValue(postgresqlOptions
                                     .getIntValue(Constants.Options.PREPARED_STATEMENT_CACHE_SIZE_MIB));
-                if (preparedStatementCacheSize > 0) {
+                if (preparedStatementCacheSize >= 0) {
                     options.put(Constants.DatabaseProps.PREPARED_STATEMENT_CACHE_SIZE_MIB, preparedStatementCacheSize);
                 }
             }


### PR DESCRIPTION
## Purpose
This is backported PR to fix the bug https://github.com/ballerina-platform/ballerina-library/issues/7345

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
