### PR TITLE
Provide a way to set the current schema when initializing the db connection

### DIFF
--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -158,6 +158,7 @@ type ClientConfiguration record {|
 #                         so that the cancel message itself can get stuck. The default value is 10 seconds
 # + keepAliveTcpProbe - Enable or disable the TCP keep-alive probe
 # + binaryTransfer - Use the binary format for sending and receiving data if possible
+# + currentSchema - The schema to be used by the client
 public type Options record {|
     SecureSocket ssl?;
     decimal connectTimeout = 0;
@@ -172,6 +173,7 @@ public type Options record {|
     decimal cancelSignalTimeout = 10;
     boolean keepAliveTcpProbe?;
     boolean binaryTransfer?;
+    string currentSchema?;
 |};
 
 # Possible values for the SSL mode.

--- a/ballerina/tests/connection-init-test.bal
+++ b/ballerina/tests/connection-init-test.bal
@@ -254,6 +254,20 @@ function testWithConnectionParams3() returns error? {
 @test:Config {
     groups: ["connection", "connection-init"]
 }
+function testWithConnectionDBSchema() returns error? {
+    Options options = {
+        currentSchema: "test_schema"
+    };
+    Client dbClient = check new (host = host, username = user, password = password, options = options);
+    int count = check dbClient->queryRow(`Select count(*) from "NumericTypes3"`);
+    test:assertEquals(count, 1, "Initialising connection with custom schema failed.");
+    error? exitCode = dbClient.close();
+    test:assertExactEquals(exitCode, (), "Initialising connection with custom schema failed.");
+}
+
+@test:Config {
+    groups: ["connection", "connection-init"]
+}
 function testWithConnectionParams4() returns error? {
     sql:ConnectionPool connectionPool = {
         maxOpenConnections: 25,

--- a/ballerina/tests/resources/sql-scripts/init-scripts/table-init-script.sql
+++ b/ballerina/tests/resources/sql-scripts/init-scripts/table-init-script.sql
@@ -910,3 +910,46 @@ INSERT INTO ArrayTypes5 (
    ARRAY[Null, Null] :: MONEY ARRAY,
    ARRAY[Null, Null] :: PG_LSN ARRAY
    );
+
+DROP SCHEMA IF EXISTS "test_schema" CASCADE;
+
+CREATE SCHEMA "test_schema";
+
+CREATE TABLE "test_schema"."NumericTypes3" (
+  row_id SERIAL,
+  smallint_type SMALLINT,
+  int_type INTEGER,
+  bigint_type BIGINT,
+  decimal_type DECIMAL,
+  numeric_type NUMERIC,
+  real_type REAL,
+  double_type DOUBLE PRECISION,
+  smallserial_type SMALLSERIAL,
+  serial_type SERIAL,
+  bigserial_type BIGSERIAL,
+  PRIMARY KEY (row_id)
+);
+
+INSERT INTO "test_schema"."NumericTypes3" (
+  smallint_type,
+  int_type,
+  bigint_type,
+  decimal_type,
+  numeric_type,
+  real_type,
+  double_type,
+  smallserial_type,
+  serial_type,
+  bigserial_type
+) VALUES (
+  1,
+  123,
+  123456,
+  123.456,
+  123.456,
+  234.567,
+  234.567,
+  1,
+  123,
+  123456
+);

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- [Provide a way to set the current schema when initializing the db connection](https://github.com/ballerina-platform/ballerina-library/issues/7517)
+
+## [1.13.2] - 2024-11-11
+
+### Added
 - [Allow prepareThreshold, preparedStatementCacheQueries and preparedStatementCacheSizeMiB to pass 0 values](https://github.com/ballerina-platform/ballerina-standard-library/issues/7345)
 
 ## [1.10.0] - 2023-06-30

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -87,6 +87,7 @@ public isolated function init(string host = "localhost", string? username = "pos
   #                         so that the cancel message itself can get stuck. The default value is 10 seconds
   # + keepAliveTcpProbe - Enable or disable the TCP keep-alive probe
   # + binaryTransfer - Use the binary format for sending and receiving data if possible
+  # + currentSchema - The schema to be used by the client
   public type Options record {|
       SecureSocket ssl = {};
       decimal connectTimeout = 0;
@@ -101,6 +102,7 @@ public isolated function init(string host = "localhost", string? username = "pos
       decimal cancelSignalTimeout = 10;
       boolean keepAliveTcpProbe?;
       boolean binaryTransfer?;
+      string currentSchema?;
   |};
   ``` 
 * SSL Connection:

--- a/native/src/main/java/io/ballerina/stdlib/postgresql/Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/postgresql/Constants.java
@@ -62,6 +62,7 @@ public final class Constants {
         public static final BString CANCEL_SIGNAL_TIMEOUT = StringUtils.fromString("cancelSignalTimeout");
         public static final BString TCP_KEEP_ALIVE = StringUtils.fromString("keepAliveTcpProbe");
         public static final BString BINARY_TRANSFER = StringUtils.fromString("binaryTransfer");
+        public static final BString CURRENT_SCHEMA = StringUtils.fromString("currentSchema");
     }
     /**
      * Constants for ssl configuration.
@@ -112,6 +113,7 @@ public final class Constants {
         public static final BString LOGIN_TIMEOUT = StringUtils.fromString("loginTimeout");
         public static final BString ROW_FETCH_SIZE = StringUtils.fromString("defaultRowFetchSize");
         public static final BString BINARY_TRANSFER = StringUtils.fromString("binaryTransfer");
+        public static final BString CURRENT_SCHEMA = StringUtils.fromString("currentSchema");
     }
     /**
      * Constants for Out Parameter Type Names. 

--- a/native/src/main/java/io/ballerina/stdlib/postgresql/utils/Utils.java
+++ b/native/src/main/java/io/ballerina/stdlib/postgresql/utils/Utils.java
@@ -106,6 +106,10 @@ public class Utils {
                     options.put(Constants.DatabaseProps.BINARY_TRANSFER, false);
                 }
             }
+            if (postgresqlOptions.containsKey(Constants.Options.CURRENT_SCHEMA)) {
+                options.put(Constants.DatabaseProps.CURRENT_SCHEMA, postgresqlOptions
+                        .getStringValue(Constants.Options.CURRENT_SCHEMA));
+            }
             return options;
         }
         return null;


### PR DESCRIPTION
Related Issue: https://github.com/ballerina-platform/ballerina-library/issues/7517

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [x] Updated the spec
- [x] Checked native-image compatibility
