### PR TITLE
Fix CDC test failure due to downgrading method not found to warning from error

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "postgresql"
-version = "1.18.0"
+version = "1.18.1"
 authors = ["Ballerina"]
 keywords = ["client", "network", "SQL", "RDBMS", "Vendor/PostgreSQL", "Area/Database", "Type/Connector", "Type/Trigger"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-postgresql"
@@ -15,8 +15,8 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "postgresql-native"
-version = "1.18.0"
-path = "../native/build/libs/postgresql-native-1.18.0.jar"
+version = "1.18.1"
+path = "../native/build/libs/postgresql-native-1.18.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "postgresql-compiler-plugin"
 class = "io.ballerina.stdlib.postgresql.compiler.PostgreSQLCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/postgresql-compiler-plugin-1.18.0.jar"
+path = "../compiler-plugin/build/libs/postgresql-compiler-plugin-1.18.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -219,7 +219,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "cdc"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "data.jsondata"},
@@ -235,7 +235,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "postgresql"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "file"},
@@ -257,7 +257,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "postgresql.cdc.driver"
-version = "1.0.0"
+version = "1.0.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerinax", name = "postgresql.driver"}

--- a/ballerina/tests/listener_tests.bal
+++ b/ballerina/tests/listener_tests.bal
@@ -252,8 +252,10 @@ function testCdcListenerEvents() returns error? {
         `INSERT INTO vendors (id, name, contact_info) 
         VALUES (201, 'Vendor A', 'contact@vendora.com')`);
     runtime:sleep(sleepBetweenSteps);
-    test:assertEquals(onErrorCount, 3, msg = "Error count mismatch.");
-    // 1,2 for onRead method not present, 3 for payload binding failure
+    test:assertEquals(onErrorCount, 1, msg = "Error count mismatch.");
+    // Only the payload binding failure is delivered via onError.
+    // The two missing-onRead occurrences are emitted as warnings on stderr
+    // by the CDC runtime and are not counted here.
 
     check testListener.gracefulStop();
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -59,5 +59,5 @@ stdlibTransactionVersion=1.12.0
 
 # Ballerina extended library
 stdlibPostgresqlDriverVersion=1.6.3
-stdlibCdcVersion=1.3.0
+stdlibCdcVersion=1.3.1
 stdlibPostgresCdcDriverVersion=1.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -60,4 +60,4 @@ stdlibTransactionVersion=1.12.0
 # Ballerina extended library
 stdlibPostgresqlDriverVersion=1.6.3
 stdlibCdcVersion=1.3.1
-stdlibPostgresCdcDriverVersion=1.0.0
+stdlibPostgresCdcDriverVersion=1.0.2


### PR DESCRIPTION
## Summary
- Bump `stdlibCdcVersion` from 1.3.0 to 1.3.1 (and the auto-generated native jar versions in `Ballerina.toml`, `CompilerPlugin.toml`, `Dependencies.toml`).
- Update `testCdcListenerEvents` to expect a single `onError` invocation. CDC 1.3.1 (see ballerina-platform/module-ballerinax-cdc#36) now emits a stderr warning instead of invoking `onError` when a service is missing an event remote function (e.g. `onRead`), so the two `onRead`-not-available cases are no longer counted alongside the payload-binding error.

## Test plan
- [ ] `./gradlew :postgresql-ballerina:test -Pgroups=cdc -Ptests=testCdcListenerEvents` passes
- [ ] Test output shows two `warning: Function 'onRead' is not available.` lines on stderr (visual check; not asserted)
- [ ] Full ballerina test suite passes (no regressions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request updates dependency versions for the PostgreSQL module to align with CDC stdlib 1.3.1 and adjusts a test to match the CDC runtime's changed behavior.

## Key Changes

- Dependency and build updates:
  - Bumped stdlib CDC version to 1.3.1 (gradle.properties).
  - Updated PostgreSQL module version to 1.18.1 and corresponding native JAR references (ballerina/Ballerina.toml, CompilerPlugin.toml).
  - Updated dependency versions in Dependencies.toml: ballerinax:cdc → 1.3.1, ballerinax:postgresql → 1.18.1, ballerinax:postgresql.cdc.driver → 1.0.2.
  - Updated native JAR paths to match new package versions.

- Test adjustment:
  - Modified testCdcListenerEvents to expect a single onError invocation (onError count changed from 3 to 1).
  - Tests now reflect that CDC 1.3.1 emits stderr warnings for missing event remote functions (e.g., onRead) instead of invoking onError for those cases; only the payload-binding error is asserted as an onError invocation.

## Intended Outcome

Align runtime and build artifacts with CDC 1.3.1 and ensure tests reflect the updated CDC behavior to avoid false failures while preserving validation of genuine payload-binding errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/module-ballerinax-postgresql/pull/1257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->