### PR TITLE
Update cdc version

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -46,7 +46,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -219,7 +219,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "cdc"
-version = "1.3.1"
+version = "1.3.2"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "data.jsondata"},

--- a/gradle.properties
+++ b/gradle.properties
@@ -59,5 +59,5 @@ stdlibTransactionVersion=1.12.0
 
 # Ballerina extended library
 stdlibPostgresqlDriverVersion=1.6.3
-stdlibCdcVersion=1.3.1
+stdlibCdcVersion=1.3.2
 stdlibPostgresCdcDriverVersion=1.0.2


### PR DESCRIPTION
## Purpose

$ subject - to fix islive test failures

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request updates Ballerina dependencies to resolve test failures. The changes include upgrading the CDC library from version 1.3.1 to 1.3.2 and the IO library from version 1.8.0 to 1.8.1 across both the dependency configuration file and the Gradle build properties.

## Changes

- **ballerina/Dependencies.toml**: Updated `ballerinax:cdc` from 1.3.1 to 1.3.2 and `ballerina:io` from 1.8.0 to 1.8.1
- **gradle.properties**: Updated `stdlibCdcVersion` property from 1.3.1 to 1.3.2

These dependency updates are intended to improve stability and resolve islive test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->