### PR TITLE
Bump cdc/postgresql.driver/postgresql.cdc.driver for Debezium 3.5.1

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -9,21 +9,6 @@ icon = "icon.png"
 license = ["Apache-2.0"]
 distribution = "2201.13.0"
 
-[[dependency]]
-org = "ballerinax"
-name = "cdc"
-version = "1.4.0"
-
-[[dependency]]
-org = "ballerinax"
-name = "postgresql.cdc.driver"
-version = "1.1.0"
-
-[[dependency]]
-org = "ballerinax"
-name = "postgresql.driver"
-version = "1.7.0"
-
 [platform.java21]
 graalvmCompatible = true
 

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "postgresql"
-version = "1.18.1"
+version = "1.19.0"
 authors = ["Ballerina"]
 keywords = ["client", "network", "SQL", "RDBMS", "Vendor/PostgreSQL", "Area/Database", "Type/Connector", "Type/Trigger"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-postgresql"
@@ -9,14 +9,29 @@ icon = "icon.png"
 license = ["Apache-2.0"]
 distribution = "2201.13.0"
 
+[[dependency]]
+org = "ballerinax"
+name = "cdc"
+version = "1.4.0"
+
+[[dependency]]
+org = "ballerinax"
+name = "postgresql.cdc.driver"
+version = "1.1.0"
+
+[[dependency]]
+org = "ballerinax"
+name = "postgresql.driver"
+version = "1.7.0"
+
 [platform.java21]
 graalvmCompatible = true
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "postgresql-native"
-version = "1.18.1"
-path = "../native/build/libs/postgresql-native-1.18.1-SNAPSHOT.jar"
+version = "1.19.0"
+path = "../native/build/libs/postgresql-native-1.19.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "postgresql-compiler-plugin"
 class = "io.ballerina.stdlib.postgresql.compiler.PostgreSQLCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/postgresql-compiler-plugin-1.18.1-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/postgresql-compiler-plugin-1.19.0-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -22,7 +22,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -31,7 +31,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.13.0"
+version = "1.12.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.13.0"
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.10.1"
+version = "2.12.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -31,7 +31,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.12.0"
+version = "1.13.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -199,7 +199,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -219,7 +219,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "cdc"
-version = "1.3.2"
+version = "1.4.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "data.jsondata"},
@@ -235,7 +235,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "postgresql"
-version = "1.18.1"
+version = "1.19.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "file"},
@@ -257,7 +257,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "postgresql.cdc.driver"
-version = "1.0.2"
+version = "1.1.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerinax", name = "postgresql.driver"}
@@ -269,7 +269,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "postgresql.driver"
-version = "1.6.3"
+version = "1.7.0"
 scope = "testOnly"
 modules = [
 	{org = "ballerinax", packageName = "postgresql.driver", moduleName = "postgresql.driver"}

--- a/ballerina/tests/resources/compose.yaml
+++ b/ballerina/tests/resources/compose.yaml
@@ -1,3 +1,4 @@
+name: ballerinax-postgresql-tests
 services:
     image-build:
         build: .

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -9,21 +9,6 @@ icon = "icon.png"
 license = ["Apache-2.0"]
 distribution = "2201.13.0"
 
-[[dependency]]
-org = "ballerinax"
-name = "cdc"
-version = "1.4.0"
-
-[[dependency]]
-org = "ballerinax"
-name = "postgresql.cdc.driver"
-version = "1.1.0"
-
-[[dependency]]
-org = "ballerinax"
-name = "postgresql.driver"
-version = "1.7.0"
-
 [platform.java21]
 graalvmCompatible = true
 

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -9,6 +9,21 @@ icon = "icon.png"
 license = ["Apache-2.0"]
 distribution = "2201.13.0"
 
+[[dependency]]
+org = "ballerinax"
+name = "cdc"
+version = "1.4.0"
+
+[[dependency]]
+org = "ballerinax"
+name = "postgresql.cdc.driver"
+version = "1.1.0"
+
+[[dependency]]
+org = "ballerinax"
+name = "postgresql.driver"
+version = "1.7.0"
+
 [platform.java21]
 graalvmCompatible = true
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Upgrade CDC dependencies to the Debezium 3.5.1-compatible release line and PostgreSQL JDBC driver 42.7.7.
+
 ## [1.18.0] - 2026-04-03
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=io.ballerina.stdlib
-version=1.18.1-SNAPSHOT
+version=1.19.0-SNAPSHOT
 ballerinaLangVersion=2201.13.0
 
 checkstylePluginVersion=10.12.1
@@ -9,7 +9,7 @@ shadowJarPluginVersion=8.1.1
 releasePluginVersion=2.8.0
 ballerinaGradlePluginVersion=2.3.0
 
-postgreSQLDriverVersion=42.6.1
+postgreSQLDriverVersion=42.7.7
 testngVersion=7.6.1
 
 # Direct Dependencies
@@ -58,6 +58,6 @@ stdlibHttpVersion=2.14.0
 stdlibTransactionVersion=1.12.0
 
 # Ballerina extended library
-stdlibPostgresqlDriverVersion=1.6.3
-stdlibCdcVersion=1.3.2
-stdlibPostgresCdcDriverVersion=1.0.2
+stdlibPostgresqlDriverVersion=1.7.0
+stdlibCdcVersion=1.4.0
+stdlibPostgresCdcDriverVersion=1.1.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ spotbugsPluginVersion=6.0.18
 downloadPluginVersion=5.4.0
 shadowJarPluginVersion=8.1.1
 releasePluginVersion=2.8.0
-ballerinaGradlePluginVersion=2.3.0
+ballerinaGradlePluginVersion=2.3.1
 
 postgreSQLDriverVersion=42.7.7
 testngVersion=7.6.1


### PR DESCRIPTION
## Summary
- Bumps `ballerinax/cdc`, `ballerinax/postgresql.cdc.driver`, and `ballerinax/postgresql.driver` to the Debezium 3.5.1-compatible release line (1.4.0 / 1.1.0 / 1.7.0 respectively) — needed for Oracle AI Database 26ai support upstream in `cdc`, and pgjdbc 42.7.7 in `postgresql.driver` to fix a `NoSuchMethodError` against Debezium 3.5.1's Postgres connector. `Dependencies.toml` locks these versions directly; no `[[dependency]]` override is needed in `Ballerina.toml`.
- Bumps the bundled `postgreSQLDriverVersion` (postgresql-native's own compile classpath) to 42.7.7 for consistency with `postgresql.driver`.
- Names the test compose project explicitly (`ballerinax-postgresql-tests`) in `ballerina/tests/resources/compose.yaml` so it can't collide with another repo's default (directory-basename-derived) compose project name when running tests locally alongside other Ballerina repos.

## Test plan
- [x] Verified locally (with the three dependencies temporarily published at their release versions) that `./gradlew build` succeeds and the full test suite passes: 398 passing, 3 failing (all unrelated to this change — one is a timezone-offset assertion that depends on the host machine's local timezone, the others are pre-existing/environment-dependent; none touch CDC), 2 skipped.
- [x] `cdc` group tests (`testCdcListenerEvents`, `testAttachAfterStart`, `testDetachAfterStart`, plus the Postgres-specific CDC config tests) all pass.

**Note:** This PR depends on the following being merged and released first, since none of the pinned versions above exist on Ballerina Central yet. Until then, `bal test` won't compile — `postgresql.cdc.driver`/`postgresql.driver` are `testOnly` dependencies with no released version to resolve, and there's intentionally no local/override pin in `Ballerina.toml` to mask that:
- [ballerinax/cdc#42](https://github.com/ballerina-platform/module-ballerinax-cdc/pull/42)
- [ballerinax/postgresql.driver#47](https://github.com/ballerina-platform/module-ballerinax-postgresql.driver/pull/47)
- [ballerinax/postgresql.cdc.driver#8](https://github.com/ballerina-platform/module-ballerinax-postgresql.cdc.driver/pull/8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated PostgreSQL packages, native JARs, and the compiler plugin to `1.19.0`.
- Updated CDC dependencies for Debezium 3.5.1 compatibility.
- Updated the bundled PostgreSQL JDBC driver to `42.7.7`.
- Added the Compose project name `ballerinax-postgresql-tests`.
- Recorded the dependency updates in `changelog.md`.
- Verification reported 398 passing tests, with CDC-related tests passing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->